### PR TITLE
参数过滤插件优化,新增key测试功能

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
       - "v*"
   workflow_dispatch:
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
@@ -15,6 +19,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -37,19 +42,14 @@ jobs:
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             VERSION="${GITHUB_REF_NAME#v}"
           else
-            VERSION=$(python - <<'PY'
-import re
-
-text = open('pyproject.toml', 'r', encoding='utf-8').read()
-m = re.search(r"(?m)^version\s*=\s*(['\"])([^'\"]+)\1\s*$", text)
-print(m.group(2) if m else '')
-PY
-            )
+            VERSION=$(grep -E '^version\s*=\s*"' pyproject.toml | head -n 1 | cut -d'"' -f2)
           fi
+
           if [[ -z "$VERSION" ]]; then
             echo "::error::Failed to resolve version"
             exit 1
           fi
+
           echo "Resolved version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -58,6 +58,17 @@ PY
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Resolve build platforms
+        id: platforms
+        shell: bash
+        run: |
+          # Tag 构建才做多架构，避免 main 分支每次提交都耗时过长
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          else
+            echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -82,9 +93,11 @@ PY
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,21 @@ name: Build and Release PEX
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-pex-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   build:
-    if: startsWith(github.event.head_commit.message, 'v')
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -19,20 +27,10 @@ jobs:
             arch: arm64
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
-      - name: Install pex
-        run: pip install pex
-
-      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up uv
@@ -43,45 +41,93 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          # pyproject.toml: requires-python >= 3.11
+          python-version: '3.11'
 
-      - name: Install dependencies with uv
-        run: uv pip install -r pyproject.toml
-        env:
-          UV_SYSTEM_PYTHON: 1
-
-      - name: Get Version
-        id: get_version
+      - name: Install build tools
         run: |
-          VERSION=$(grep "^version = " pyproject.toml | awk -F'"' '{print $2}')
+          python -m pip install --upgrade pip
+          python -m pip install pex
+
+      - name: Resolve Version
+        id: resolve_version
+        shell: bash
+        run: |
+          # tag 触发：优先使用 tag（vX.Y.Z -> X.Y.Z）
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(python - <<'PY'
+          import re
+          text = open('pyproject.toml', 'r', encoding='utf-8').read()
+          m = re.search(r"(?m)^version\s*=\s*\"([^\"]+)\"\s*$", text)
+          print(m.group(1) if m else '')
+          PY
+            )
+          fi
+
+          if [[ -z "$VERSION" ]]; then
+            echo "::error::Failed to resolve version"
+            exit 1
+          fi
+
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Resolved VERSION=$VERSION"
 
-      - name: Build Linux PEX
-        if: matrix.platform == 'linux'
+      - name: Export dependencies (requirements.txt)
+        shell: bash
         run: |
-          pex -D . -r pyproject.toml \
-          -c uvicorn \
-          --inject-args 'main:app --host 0.0.0.0 --port 8000' \
-          --platform linux_x86_64-cp-3.10-cp310 \
-          --interpreter-constraint '==3.10.*' \
-          --no-strip-pex-env \
-          -o zoaholic-linux-x86_64-${VERSION}.pex
+          # 从 pyproject/uv.lock 导出 requirements.txt，供 pex 使用
+          uv export --format requirements-txt --no-dev -o requirements.txt
+          echo "Exported requirements.txt:"
+          head -n 50 requirements.txt
 
-      - name: Build MacOS PEX
-        if: matrix.platform == 'macos'
+      - name: Build PEX
+        shell: bash
         run: |
-          pex -r pyproject.toml \
-          -c uvicorn \
-          --inject-args 'main:app --host 0.0.0.0 --port 8000' \
-          -o zoaholic-macos-arm64-${VERSION}.pex
+          OUT="zoaholic-${{ matrix.platform }}-${{ matrix.arch }}-${VERSION}.pex"
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
+          pex -D . -r requirements.txt \
+            -c uvicorn \
+            --inject-args 'main:app --host 0.0.0.0 --port 8000' \
+            --interpreter-constraint '==3.11.*' \
+            -o "$OUT"
+
+          ls -lh "$OUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pex-${{ matrix.platform }}-${{ matrix.arch }}
+          path: zoaholic-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.VERSION }}.pex
+          if-no-files-found: error
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: List artifacts
+        shell: bash
+        run: |
+          ls -R dist
+
+      - name: Create GitHub Release (upload all PEX)
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: Release ${{ env.VERSION }}
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           draft: false
           prerelease: false
           files: |
-            zoaholic-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.VERSION }}.pex
+            dist/**/*.pex

--- a/core/channels/claude_channel.py
+++ b/core/channels/claude_channel.py
@@ -8,6 +8,7 @@ import json
 import copy
 import asyncio
 from datetime import datetime
+from urllib.parse import urlparse, urlunparse
 
 from ..utils import (
     safe_get,
@@ -24,6 +25,52 @@ from ..response import check_response
 # ============================================================
 # Claude 格式化函数
 # ============================================================
+
+
+def _anthropic_build_v1_url(base_url: str, suffix: str) -> str:
+    """根据用户配置的 base_url 构造 Anthropic v1 下的具体端点 URL。
+
+    兼容以下几种填写方式：
+    - https://api.anthropic.com/v1
+    - https://api.anthropic.com/v1/
+    - https://api.anthropic.com/v1/messages
+    - https://api.anthropic.com/v1/messages/
+    - https://<proxy>/any/prefix/v1/messages
+
+    Args:
+        base_url: 渠道配置中的 base_url
+        suffix: 端点后缀，如 "messages" / "models"（可带或不带前导 /）
+
+    Returns:
+        str: 拼接后的完整 URL
+    """
+
+    if not base_url:
+        return ""
+
+    suffix = str(suffix or "").strip()
+    suffix = suffix.lstrip("/")
+
+    parsed = urlparse(str(base_url).strip())
+    path = (parsed.path or "").rstrip("/")
+
+    # 1) 如果用户填的是 /v1/messages，把 /messages 去掉
+    if path.endswith("/messages"):
+        path = path[: -len("/messages")]
+
+    # 2) 确保落在 .../v1
+    if not path.endswith("/v1"):
+        # 尝试截断到最后一个 /v1（支持自建反代前缀）
+        idx = path.rfind("/v1")
+        if idx != -1 and (idx + 3 == len(path) or path[idx + 3 : idx + 4] == "/"):
+            path = path[: idx + 3]
+        else:
+            path = (path + "/v1") if path else "/v1"
+
+    # 3) 拼接 suffix
+    final_path = f"{path}/{suffix}" if suffix else path
+
+    return urlunparse((parsed.scheme, parsed.netloc, final_path, "", "", ""))
 
 def format_text_message(text: str) -> dict:
     """格式化文本消息为 Claude 格式"""
@@ -150,7 +197,10 @@ async def get_claude_payload(request, engine, provider, api_key=None):
         "anthropic-version": "2023-06-01",
         "anthropic-beta": anthropic_beta,
     }
-    url = provider['base_url']
+    # 兼容 base_url 填 /v1 或 /v1/messages
+    url = _anthropic_build_v1_url(provider.get('base_url', ''), 'messages')
+    if not url:
+        url = provider.get('base_url', '')
 
     messages = []
     system_prompt = None
@@ -510,6 +560,42 @@ async def fetch_claude_response_stream(client, url, headers, payload, model, tim
     yield "data: [DONE]" + end_of_line
 
 
+async def fetch_claude_models(client, provider):
+    """获取 Anthropic Claude API 的模型列表。
+
+    兼容 base_url 填写：
+    - .../v1
+    - .../v1/messages
+    """
+
+    api_key = provider.get("api")
+    if isinstance(api_key, list):
+        api_key = api_key[0] if api_key else None
+
+    headers = {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+    }
+    if api_key:
+        headers["x-api-key"] = str(api_key)
+
+    base_url = provider.get("base_url", "")
+    url = _anthropic_build_v1_url(base_url, "models")
+    if not url:
+        # 兜底：尽量按 OpenAI 习惯拼接
+        url = str(base_url).rstrip("/") + "/models"
+
+    response = await client.get(url, headers=headers)
+    response.raise_for_status()
+
+    data = response.json()
+    models = []
+    if isinstance(data, dict) and isinstance(data.get("data"), list):
+        models = [m.get("id") for m in data["data"] if isinstance(m, dict) and m.get("id")]
+
+    return models
+
+
 def register():
     """注册 Claude 渠道到注册中心"""
     from .registry import register_channel
@@ -524,5 +610,5 @@ def register():
         passthrough_payload_adapter=patch_passthrough_claude_payload,
         response_adapter=fetch_claude_response,
         stream_adapter=fetch_claude_response_stream,
-        models_adapter=None,
+        models_adapter=fetch_claude_models,
     )

--- a/core/utils.py
+++ b/core/utils.py
@@ -82,7 +82,8 @@ class BaseAPI:
         self.base_url: str = urlunparse(parsed_url[:2] + ("",) + ("",) * 3)
         self.v1_url: str = urlunparse(parsed_url[:2]+ (before_v1,) + ("",) * 3)
         if "v1/messages" in parsed_url.path:
-            self.v1_models: str = urlunparse(parsed_url[:2] + ("v1/models",) + ("",) * 3)
+            # 注意：path 必须以 / 开头，否则 urlunparse 会生成无效 URL（缺少 /）
+            self.v1_models: str = urlunparse(parsed_url[:2] + ("/v1/models",) + ("",) * 3)
         else:
             self.v1_models: str = urlunparse(parsed_url[:2] + (before_v1 + "models",) + ("",) * 3)
 

--- a/frontend/src/components/ApiKeyTestDialog.tsx
+++ b/frontend/src/components/ApiKeyTestDialog.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import {
+  X,
+  Play,
+  Square,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Copy,
+  CopyCheck,
+} from 'lucide-react';
+import { apiFetch } from '../lib/api';
+import { useAuthStore } from '../store/authStore';
+
+export interface ApiKeyObj {
+  key: string;
+  disabled: boolean;
+}
+
+interface KeyTestResult {
+  status: 'pending' | 'testing' | 'success' | 'error';
+  latency_ms?: number | null;
+  upstream_status_code?: number | null;
+  auth_failed?: boolean;
+  error?: string | null;
+  response_preview?: string | null;
+}
+
+export interface ApiKeyTestDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+
+  title?: string;
+
+  engine: string;
+  base_url: string;
+  provider_snapshot: any;
+
+  apiKeys: ApiKeyObj[];
+  availableModels: string[];
+
+  initialKeyIndex?: number | null;
+
+  /** 用于把「失效 key」标记为 disabled（仅修改当前编辑中的 formData，保存后生效） */
+  onDisableKeys?: (indices: number[]) => void;
+}
+
+export function ApiKeyTestDialog({
+  open,
+  onOpenChange,
+  title,
+  engine,
+  base_url,
+  provider_snapshot,
+  apiKeys,
+  availableModels,
+  initialKeyIndex,
+  onDisableKeys,
+}: ApiKeyTestDialogProps) {
+  const { token } = useAuthStore();
+
+  const [model, setModel] = useState('');
+  const [temperature, setTemperature] = useState(0.5);
+  const [stream, setStream] = useState(false);
+  const [maxTokens, setMaxTokens] = useState(16);
+  const [timeoutSec, setTimeoutSec] = useState(30);
+  const [concurrency, setConcurrency] = useState(3);
+
+  const [includeDisabled, setIncludeDisabled] = useState(false);
+  const [autoDisableInvalid, setAutoDisableInvalid] = useState(true);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const runningRef = useRef(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const [results, setResults] = useState<Map<number, KeyTestResult>>(new Map());
+  const [copiedKeyIndex, setCopiedKeyIndex] = useState<number | null>(null);
+
+  const modelOptions = useMemo(() => {
+    const set = new Set<string>();
+    (availableModels || []).forEach(m => {
+      const s = String(m || '').trim();
+      if (s) set.add(s);
+    });
+    return Array.from(set);
+  }, [availableModels]);
+
+  // open 时初始化
+  useEffect(() => {
+    if (!open) return;
+
+    const firstModel = modelOptions[0] || '';
+    setModel(prev => (prev ? prev : firstModel));
+
+    const init = new Map<number, KeyTestResult>();
+    apiKeys.forEach((_, idx) => {
+      init.set(idx, { status: 'pending' });
+    });
+    setResults(init);
+
+    // 自动触发单 key 测试（如果从单 key 按钮进入）
+    if (typeof initialKeyIndex === 'number' && initialKeyIndex >= 0) {
+      // 延迟一帧，避免弹窗开启动画期间卡顿
+      setTimeout(() => {
+        void testSingleKey(initialKeyIndex);
+      }, 50);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open && isRunning) {
+      stopAll();
+    }
+  }, [open]);
+
+  const canRun = () => {
+    const hasModel = Boolean(model.trim());
+    const hasKey = apiKeys.some(k => (includeDisabled || !k.disabled) && k.key.trim());
+    return hasModel && hasKey;
+  };
+
+  const testSingleKey = async (idx: number) => {
+    const keyObj = apiKeys[idx];
+    if (!keyObj) return;
+    if (!includeDisabled && keyObj.disabled) return;
+
+    const apiKey = keyObj.key.trim();
+    if (!apiKey) return;
+
+    setResults(prev => {
+      const next = new Map(prev);
+      next.set(idx, { status: 'testing', latency_ms: null, error: null });
+      return next;
+    });
+
+    try {
+      const res = await apiFetch('/v1/channels/test', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          engine: engine || 'openai',
+          base_url,
+          provider_snapshot,
+          api_key: apiKey,
+          model: model.trim(),
+          temperature,
+          stream,
+          max_tokens: maxTokens,
+          timeout: timeoutSec,
+        }),
+        signal: abortControllerRef.current?.signal,
+      });
+
+      const data = await res.json().catch(() => ({} as any));
+
+      if (res.ok && data?.success) {
+        setResults(prev => {
+          const next = new Map(prev);
+          next.set(idx, {
+            status: 'success',
+            latency_ms: data.latency_ms ?? null,
+            upstream_status_code: data.upstream_status_code ?? null,
+            auth_failed: Boolean(data.auth_failed),
+            error: null,
+            response_preview: data.response_preview ?? null,
+          });
+          return next;
+        });
+        return;
+      }
+
+      const errMsg = data?.error || data?.detail || data?.message || `HTTP ${res.status}`;
+      const authFailed = Boolean(data?.auth_failed);
+
+      setResults(prev => {
+        const next = new Map(prev);
+        next.set(idx, {
+          status: 'error',
+          latency_ms: data?.latency_ms ?? null,
+          upstream_status_code: data?.upstream_status_code ?? null,
+          auth_failed: authFailed,
+          error: String(errMsg),
+          response_preview: data?.response_preview ?? null,
+        });
+        return next;
+      });
+
+      if (autoDisableInvalid && authFailed && onDisableKeys) {
+        onDisableKeys([idx]);
+      }
+    } catch (e: any) {
+      if (e?.name === 'AbortError') {
+        setResults(prev => {
+          const next = new Map(prev);
+          next.set(idx, { status: 'pending' });
+          return next;
+        });
+        return;
+      }
+
+      setResults(prev => {
+        const next = new Map(prev);
+        next.set(idx, {
+          status: 'error',
+          error: e?.message || String(e),
+        });
+        return next;
+      });
+    }
+  };
+
+  const startAll = async () => {
+    if (!canRun()) {
+      alert('请先设置模型，并确保至少有一个可测试的 Key');
+      return;
+    }
+
+    runningRef.current = true;
+    setIsRunning(true);
+    abortControllerRef.current = new AbortController();
+
+    // reset
+    setResults(prev => {
+      const next = new Map(prev);
+      apiKeys.forEach((_, idx) => {
+        next.set(idx, { status: 'pending' });
+      });
+      return next;
+    });
+
+    const queue = apiKeys
+      .map((k, idx) => ({ k, idx }))
+      .filter(({ k }) => (includeDisabled || !k.disabled) && Boolean(k.key.trim()))
+      .map(({ idx }) => idx);
+
+    const runNext = async () => {
+      while (queue.length > 0) {
+        if (!runningRef.current) return;
+        const idx = queue.shift();
+        if (idx === undefined) return;
+        await testSingleKey(idx);
+      }
+    };
+
+    const tasks: Promise<void>[] = [];
+    for (let i = 0; i < Math.max(1, Math.min(10, concurrency)); i++) {
+      tasks.push(runNext());
+    }
+
+    await Promise.all(tasks);
+    runningRef.current = false;
+    setIsRunning(false);
+  };
+
+  const stopAll = () => {
+    runningRef.current = false;
+    setIsRunning(false);
+    abortControllerRef.current?.abort();
+  };
+
+  const copyKey = (idx: number) => {
+    const apiKey = apiKeys[idx]?.key?.trim();
+    if (!apiKey) return;
+    navigator.clipboard.writeText(apiKey);
+    setCopiedKeyIndex(idx);
+    setTimeout(() => setCopiedKeyIndex(null), 1500);
+  };
+
+  const statusIcon = (r: KeyTestResult) => {
+    switch (r.status) {
+      case 'pending':
+        return <Clock className="w-5 h-5 text-muted-foreground" />;
+      case 'testing':
+        return <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />;
+      case 'success':
+        return <CheckCircle2 className="w-5 h-5 text-emerald-500" />;
+      case 'error':
+        return <XCircle className="w-5 h-5 text-red-500" />;
+    }
+  };
+
+  const successCount = Array.from(results.values()).filter(r => r.status === 'success').length;
+  const errorCount = Array.from(results.values()).filter(r => r.status === 'error').length;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[80] animate-in fade-in duration-200" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[760px] max-w-[96vw] max-h-[90vh] bg-background border border-border rounded-xl shadow-2xl z-[90] flex flex-col">
+          {/* Header */}
+          <div className="p-5 border-b border-border flex justify-between items-center bg-muted/30 flex-shrink-0">
+            <Dialog.Title className="text-lg font-bold text-foreground">
+              {title || 'API Key 测试'}
+            </Dialog.Title>
+            <Dialog.Close className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </Dialog.Close>
+          </div>
+
+          {/* Controls */}
+          <div className="p-4 border-b border-border flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {!isRunning ? (
+                <button
+                  onClick={startAll}
+                  className="bg-primary hover:bg-primary/90 text-primary-foreground px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium transition-colors"
+                >
+                  <Play className="w-4 h-4" /> 测试全部 Key
+                </button>
+              ) : (
+                <button
+                  onClick={stopAll}
+                  className="bg-red-500/10 border border-red-500/40 text-red-600 dark:text-red-400 hover:bg-red-500/20 px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium transition-colors"
+                >
+                  <Square className="w-4 h-4" /> 停止
+                </button>
+              )}
+
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">并发</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={concurrency}
+                  onChange={e => setConcurrency(Math.max(1, Math.min(10, parseInt(e.target.value) || 1)))}
+                  className="w-16 bg-background border border-border rounded px-2 py-1 text-center text-sm text-foreground"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">超时(秒)</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={120}
+                  value={timeoutSec}
+                  onChange={e => setTimeoutSec(Math.max(1, Math.min(120, parseInt(e.target.value) || 30)))}
+                  className="w-20 bg-background border border-border rounded px-2 py-1 text-center text-sm text-foreground"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Max Tokens</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={2048}
+                  value={maxTokens}
+                  onChange={e => setMaxTokens(Math.max(1, Math.min(2048, parseInt(e.target.value) || 16)))}
+                  className="w-24 bg-background border border-border rounded px-2 py-1 text-center text-sm text-foreground"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">温度</span>
+                <input
+                  type="number"
+                  step={0.1}
+                  min={0}
+                  max={2}
+                  value={temperature}
+                  onChange={e => setTemperature(Math.max(0, Math.min(2, parseFloat(e.target.value) || 0)))}
+                  className="w-20 bg-background border border-border rounded px-2 py-1 text-center text-sm text-foreground"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-muted-foreground block mb-1">模型</label>
+                {modelOptions.length > 0 ? (
+                  <select
+                    value={model}
+                    onChange={e => setModel(e.target.value)}
+                    className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground"
+                  >
+                    {modelOptions.map(m => (
+                      <option key={m} value={m}>{m}</option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    value={model}
+                    onChange={e => setModel(e.target.value)}
+                    placeholder={'例如：gpt-4o-mini'}
+                    className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground"
+                  />
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <label className="text-xs text-muted-foreground block">选项</label>
+                <div className="flex flex-wrap items-center gap-4 text-sm">
+                  <label className="inline-flex items-center gap-2">
+                    <input type="checkbox" checked={stream} onChange={e => setStream(e.target.checked)} />
+                    <span>流式输出</span>
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input type="checkbox" checked={includeDisabled} onChange={e => setIncludeDisabled(e.target.checked)} />
+                    <span>包含已禁用 Key</span>
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={autoDisableInvalid}
+                      onChange={e => setAutoDisableInvalid(e.target.checked)}
+                    />
+                    <span>鉴权失败自动禁用</span>
+                  </label>
+                </div>
+                {autoDisableInvalid && (
+                  <p className="text-xs text-muted-foreground">
+                    说明：仅在后端判断 <span className="font-mono">auth_failed=true</span>（通常是 401/403）时，才会自动把 Key 标记为禁用；需要保存渠道配置后才会生效。
+                  </p>
+                )}
+              </div>
+            </div>
+
+            
+          </div>
+
+          {/* List */}
+          <div className="flex-1 overflow-y-auto">
+            <ul className="divide-y divide-border">
+              {apiKeys.map((k, idx) => {
+                const r = results.get(idx) || { status: 'pending' as const };
+                const keyText = k.key?.trim() || '';
+
+                const hint = r.status === 'success'
+                  ? `${r.latency_ms ?? '-'}ms${r.upstream_status_code ? ` · ${r.upstream_status_code}` : ''}`
+                  : r.status === 'error'
+                    ? (r.error || '测试失败')
+                    : r.status === 'testing'
+                      ? '正在测试...'
+                      : '等待测试';
+
+                return (
+                  <li key={idx} className={`px-4 py-3 flex items-center gap-3 ${k.disabled ? 'opacity-60' : ''}`}>
+                    <div className="w-10 h-10 flex items-center justify-center flex-shrink-0">
+                      {statusIcon(r)}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-xs text-muted-foreground w-8 text-right flex-shrink-0">{idx + 1}</span>
+                        <span className={`font-mono text-sm truncate ${k.disabled ? 'line-through text-muted-foreground' : 'text-foreground'}`} title={keyText}>
+                          {keyText || '(空)'}
+                        </span>
+                        {copiedKeyIndex === idx ? (
+                          <CopyCheck className="w-3.5 h-3.5 text-emerald-500 flex-shrink-0" />
+                        ) : (
+                          <button
+                            className="text-muted-foreground hover:text-foreground"
+                            onClick={() => copyKey(idx)}
+                            title="复制 Key"
+                          >
+                            <Copy className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                      </div>
+
+                      <div className={`text-xs truncate ${r.status === 'error' ? 'text-red-600 dark:text-red-400' : r.status === 'success' ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`} title={typeof r.error === 'string' ? r.error : undefined}>
+                        {hint}
+                        {r.auth_failed ? <span className="ml-2 font-mono">(auth_failed)</span> : null}
+                      </div>
+
+                      {r.response_preview && (
+                        <pre className="mt-2 text-[11px] p-2 bg-muted/40 border border-border rounded max-h-[120px] overflow-auto whitespace-pre-wrap">
+                          {r.response_preview}
+                        </pre>
+                      )}
+                    </div>
+
+                    <div className="flex items-center gap-1 flex-shrink-0">
+                      <button
+                        onClick={() => void testSingleKey(idx)}
+                        disabled={r.status === 'testing' || (!includeDisabled && k.disabled) || !keyText}
+                        className="px-3 py-2 rounded-lg text-sm bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50"
+                        title="测试此 Key"
+                      >
+                        <Play className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          {/* Footer */}
+          <div className="p-4 border-t border-border bg-muted/30 flex-shrink-0 flex items-center justify-between">
+            <div className="text-xs text-muted-foreground">
+              共 {apiKeys.length} 个 Key · {successCount} 成功 · {errorCount} 失败
+            </div>
+            <div className="text-xs text-muted-foreground">
+              engine=<span className="font-mono">{engine || 'openai'}</span> · base_url=<span className="font-mono">{base_url || '-'}</span>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/components/InterceptorSheet.tsx
+++ b/frontend/src/components/InterceptorSheet.tsx
@@ -9,6 +9,8 @@ import {
   X,
 } from 'lucide-react';
 
+import { ParameterFilterEditorDialog } from './ParameterFilterEditorDialog';
+
 interface PluginOption {
   plugin_name: string;
   version: string;
@@ -34,10 +36,11 @@ interface InterceptorSheetProps {
   allPlugins: PluginOption[];
   enabledPlugins: string[]; // ["pluginA:config", "pluginB"]
   providerPreferences: Record<string, any>;
+  providerModels?: string[]; // 当前渠道已启用模型（用于某些插件的快速配置）
   onUpdate: (payload: { enabled_plugins: string[]; preferences_patch: Record<string, any>; preferences_delete: string[] }) => void;
 }
 
-export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugins, providerPreferences, onUpdate }: InterceptorSheetProps) {
+export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugins, providerPreferences, providerModels, onUpdate }: InterceptorSheetProps) {
   // Parsing helpers
   const parseEntry = (entry: string) => {
     // 约定：enabled_plugins 的单条配置使用“第一个冒号”分隔 name 与 options。
@@ -54,6 +57,8 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
   const [selected, setSelected] = useState<Map<string, string>>(new Map());
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [providerConfigText, setProviderConfigText] = useState<Map<string, string>>(new Map());
+
+  const [filterEditorOpen, setFilterEditorOpen] = useState(false);
 
   // Re-init when opening (important: same sheet instance is reused across different providers)
   useEffect(() => {
@@ -86,12 +91,30 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
     setProviderConfigText(cfgMap);
   }, [open, enabledPlugins, allPlugins, providerPreferences]);
 
+  useEffect(() => {
+    if (!open) {
+      setFilterEditorOpen(false);
+    }
+  }, [open]);
+
   // Handlers
   const toggleSelect = (pluginName: string) => {
     setSelected(prev => {
       const next = new Map(prev);
-      if (next.has(pluginName)) next.delete(pluginName);
+      const wasSelected = next.has(pluginName);
+      if (wasSelected) next.delete(pluginName);
       else next.set(pluginName, '');
+
+      // post_body_parameter_filter：启用时自动弹出单独编辑窗口
+      if (!wasSelected && pluginName === 'post_body_parameter_filter') {
+        // 确保展开
+        setExpanded(prevExpanded => {
+          const s = new Set(prevExpanded);
+          s.add(pluginName);
+          return s;
+        });
+        setTimeout(() => setFilterEditorOpen(true), 0);
+      }
       return next;
     });
   };
@@ -178,6 +201,17 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
     onOpenChange(false);
   };
 
+  const getFilterEditorInitialConfig = (): any => {
+    const raw = providerConfigText.get('post_body_parameter_filter') || '';
+    const t = raw.trim();
+    if (!t) return null;
+    try {
+      return JSON.parse(t);
+    } catch {
+      return null;
+    }
+  };
+
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -216,6 +250,7 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
                 const isSelected = selected.has(plugin.plugin_name);
                 const isExpanded = expanded.has(plugin.plugin_name);
                 const options = selected.get(plugin.plugin_name) || '';
+                const isParameterFilter = plugin.plugin_name === 'post_body_parameter_filter';
 
                 return (
                   <div key={plugin.plugin_name} className={`border rounded-lg transition-colors ${isSelected ? 'border-emerald-500/30 bg-emerald-500/5' : 'border-border bg-card'}`}>
@@ -267,18 +302,49 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
                               <p className="text-xs text-muted-foreground">{plugin.metadata.provider_config.description}</p>
                             )}
 
-                            <textarea
-                              value={providerConfigText.get(plugin.plugin_name) || ''}
-                              onChange={(e) => updateProviderConfigText(plugin.plugin_name, e.target.value)}
-                              disabled={!isSelected}
-                              rows={6}
-                              placeholder={
-                                plugin.metadata?.provider_config?.example
-                                  ? JSON.stringify(plugin.metadata.provider_config.example, null, 2)
-                                  : '请输入 JSON'
-                              }
-                              className="w-full bg-background border border-border text-foreground focus:border-emerald-500 px-3 py-2 rounded-md text-sm font-mono disabled:opacity-50 outline-none"
-                            />
+                            {isParameterFilter ? (
+                              <div className="space-y-2">
+                                <div className="flex items-center justify-between gap-2">
+                                  <p className="text-xs text-muted-foreground">
+                                    参数过滤插件建议使用“高级编辑器”配置（支持按模型快速新增规则）。
+                                  </p>
+                                  <button
+                                    type="button"
+                                    disabled={!isSelected}
+                                    onClick={() => setFilterEditorOpen(true)}
+                                    className="text-xs font-medium text-primary hover:text-primary/80 px-2 py-1 bg-primary/10 rounded disabled:opacity-50"
+                                  >
+                                    打开高级编辑器
+                                  </button>
+                                </div>
+
+                                <textarea
+                                  value={providerConfigText.get(plugin.plugin_name) || ''}
+                                  onChange={(e) => updateProviderConfigText(plugin.plugin_name, e.target.value)}
+                                  disabled={!isSelected}
+                                  rows={6}
+                                  placeholder={
+                                    plugin.metadata?.provider_config?.example
+                                      ? JSON.stringify(plugin.metadata.provider_config.example, null, 2)
+                                      : '请输入 JSON'
+                                  }
+                                  className="w-full bg-background border border-border text-foreground focus:border-emerald-500 px-3 py-2 rounded-md text-sm font-mono disabled:opacity-50 outline-none"
+                                />
+                              </div>
+                            ) : (
+                              <textarea
+                                value={providerConfigText.get(plugin.plugin_name) || ''}
+                                onChange={(e) => updateProviderConfigText(plugin.plugin_name, e.target.value)}
+                                disabled={!isSelected}
+                                rows={6}
+                                placeholder={
+                                  plugin.metadata?.provider_config?.example
+                                    ? JSON.stringify(plugin.metadata.provider_config.example, null, 2)
+                                    : '请输入 JSON'
+                                }
+                                className="w-full bg-background border border-border text-foreground focus:border-emerald-500 px-3 py-2 rounded-md text-sm font-mono disabled:opacity-50 outline-none"
+                              />
+                            )}
 
                             <div className="flex items-center gap-2">
                               <button
@@ -336,6 +402,16 @@ export function InterceptorSheet({ open, onOpenChange, allPlugins, enabledPlugin
 
         </Dialog.Content>
       </Dialog.Portal>
+
+      <ParameterFilterEditorDialog
+        open={filterEditorOpen}
+        onOpenChange={setFilterEditorOpen}
+        availableModels={providerModels || []}
+        initialConfig={getFilterEditorInitialConfig()}
+        onSave={(cfg) => {
+          updateProviderConfigText('post_body_parameter_filter', JSON.stringify(cfg, null, 2));
+        }}
+      />
     </Dialog.Root>
   );
 }

--- a/frontend/src/components/ParameterFilterEditorDialog.tsx
+++ b/frontend/src/components/ParameterFilterEditorDialog.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X, Plus, Trash2, CheckCircle2 } from 'lucide-react';
+
+type Mode = 'deny' | 'allow';
+
+export interface FilterRule {
+  modelKey: string; // 'all' 或具体模型名
+  enabled: boolean;
+  mode: Mode;
+  use_defaults: boolean;
+  deny: string[];
+  allow: string[];
+}
+
+export interface ParameterFilterEditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+
+  availableModels: string[];
+
+  /** 当前 provider.preferences.post_body_parameter_filter（可以是 object/list/null） */
+  initialConfig: any;
+
+  onSave: (config: any) => void;
+}
+
+const COMMON_FIELDS = [
+  'thinking',
+  'min_p',
+  'top_k',
+  'include_usage',
+  'stream_options.include_usage',
+  'chat_template_kwargs',
+  'response_format',
+  'tool_choice',
+  'tools',
+  'parallel_tool_calls',
+];
+
+function asStringList(v: any): string[] {
+  if (!v) return [];
+  if (Array.isArray(v)) return v.map(x => String(x)).map(s => s.trim()).filter(Boolean);
+  if (typeof v === 'string') return [v.trim()].filter(Boolean);
+  return [];
+}
+
+function normalizeRule(modelKey: string, raw: any): FilterRule {
+  const obj = (raw && typeof raw === 'object') ? raw : {};
+  const mode = (String(obj.mode || 'deny').toLowerCase() === 'allow' ? 'allow' : 'deny') as Mode;
+  const use_defaults = obj.use_defaults === undefined ? true : Boolean(obj.use_defaults);
+  const enabled = obj.enabled === false ? false : true;
+
+  return {
+    modelKey,
+    enabled,
+    mode,
+    use_defaults,
+    deny: asStringList(obj.deny),
+    allow: asStringList(obj.allow),
+  };
+}
+
+function parseConfigToRules(cfg: any): { globalRule: FilterRule; modelRules: FilterRule[] } {
+  // list => global deny
+  if (Array.isArray(cfg)) {
+    return {
+      globalRule: {
+        modelKey: 'all',
+        enabled: true,
+        mode: 'deny',
+        use_defaults: true,
+        deny: asStringList(cfg),
+        allow: [],
+      },
+      modelRules: [],
+    };
+  }
+
+  if (!cfg || typeof cfg !== 'object') {
+    return {
+      globalRule: {
+        modelKey: 'all',
+        enabled: true,
+        mode: 'deny',
+        use_defaults: true,
+        deny: [],
+        allow: [],
+      },
+      modelRules: [],
+    };
+  }
+
+  // 结构化 global
+  const hasGlobalShape = ['deny', 'allow', 'mode', 'enabled', 'use_defaults'].some(k => Object.prototype.hasOwnProperty.call(cfg, k));
+  if (hasGlobalShape) {
+    return {
+      globalRule: normalizeRule('all', cfg),
+      modelRules: [],
+    };
+  }
+
+  // all/* + per-model
+  const globalRaw = (cfg.all ?? cfg['*']) ?? {};
+  const globalRule = normalizeRule('all', globalRaw);
+
+  const modelRules: FilterRule[] = [];
+  for (const [k, v] of Object.entries(cfg)) {
+    if (k === 'all' || k === '*') continue;
+    if (!v || typeof v !== 'object') continue;
+    modelRules.push(normalizeRule(k, v));
+  }
+
+  // 稳定排序
+  modelRules.sort((a, b) => a.modelKey.localeCompare(b.modelKey));
+
+  return { globalRule, modelRules };
+}
+
+function buildConfigFromRules(globalRule: FilterRule, modelRules: FilterRule[]): any {
+  const compactRule = (r: FilterRule) => {
+    const out: any = {
+      mode: r.mode,
+      use_defaults: Boolean(r.use_defaults),
+    };
+    if (r.enabled === false) out.enabled = false;
+    if (r.deny.length) out.deny = r.deny;
+    if (r.allow.length) out.allow = r.allow;
+    return out;
+  };
+
+  const out: any = {};
+
+  // 始终写入 all（用户更容易理解结构）
+  out.all = compactRule(globalRule);
+
+  for (const r of modelRules) {
+    const key = String(r.modelKey || '').trim();
+    if (!key) continue;
+    out[key] = compactRule(r);
+  }
+
+  return out;
+}
+
+function FieldEditor({
+  title,
+  values,
+  onChange,
+}: {
+  title: string;
+  values: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [input, setInput] = useState('');
+
+  const addOne = (v: string) => {
+    const s = String(v || '').trim();
+    if (!s) return;
+    onChange(Array.from(new Set([...values, s])));
+    setInput('');
+  };
+
+  const removeOne = (v: string) => {
+    onChange(values.filter(x => x !== v));
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-xs text-muted-foreground">{title}</div>
+
+      <div className="flex flex-wrap gap-2">
+        {values.map(v => (
+          <span key={v} className="bg-muted border border-border text-foreground text-xs font-mono px-2 py-1 rounded flex items-center gap-1">
+            {v}
+            <button className="text-muted-foreground hover:text-red-500" onClick={() => removeOne(v)} title="移除">
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+        {values.length === 0 && <span className="text-xs text-muted-foreground italic">(空)</span>}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="输入字段名（支持 dot-path，例如 stream_options.include_usage）"
+          className="flex-1 bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground"
+        />
+        <button
+          type="button"
+          onClick={() => addOne(input)}
+          className="px-3 py-2 rounded-lg text-sm bg-primary/10 text-primary hover:bg-primary/20"
+        >
+          <Plus className="w-4 h-4 inline-block mr-1" /> 添加
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {COMMON_FIELDS.map(f => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => addOne(f)}
+            className="text-xs font-mono px-2 py-1 rounded bg-muted hover:bg-muted/80 border border-border text-foreground"
+            title="点击添加"
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RuleCard({
+  rule,
+  availableModels,
+  onChange,
+  onDelete,
+}: {
+  rule: FilterRule;
+  availableModels: string[];
+  onChange: (next: FilterRule) => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <div className="border border-border rounded-xl p-4 bg-card space-y-3">
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+        <div className="flex-1">
+          <label className="text-xs text-muted-foreground block mb-1">模型</label>
+          {rule.modelKey === 'all' ? (
+            <input
+              value={rule.modelKey}
+              disabled
+              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground opacity-80"
+              title="全局规则固定为 all"
+            />
+          ) : (
+            <div className="flex flex-col sm:flex-row gap-2">
+              <select
+                value={availableModels.includes(rule.modelKey) ? rule.modelKey : ''}
+                onChange={e => onChange({ ...rule, modelKey: e.target.value })}
+                className="sm:w-64 w-full bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground"
+                title="快速选择渠道中已启用的模型"
+              >
+                <option value="">(请选择模型)</option>
+                {availableModels.map(m => (
+                  <option key={m} value={m}>{m}</option>
+                ))}
+              </select>
+              <input
+                value={rule.modelKey}
+                onChange={e => onChange({ ...rule, modelKey: e.target.value })}
+                placeholder="也可手动输入自定义模型名"
+                className="flex-1 bg-background border border-border rounded-lg px-3 py-2 text-sm font-mono text-foreground"
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          <label className="text-sm inline-flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={rule.enabled}
+              onChange={e => onChange({ ...rule, enabled: e.target.checked })}
+            />
+            <span>启用</span>
+          </label>
+
+          {onDelete && (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-red-600 dark:text-red-400 hover:text-red-500"
+              title="删除该模型规则"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">模式</label>
+          <select
+            value={rule.mode}
+            onChange={e => onChange({ ...rule, mode: (e.target.value === 'allow' ? 'allow' : 'deny') as Mode })}
+            className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground"
+          >
+            <option value="deny">deny（移除这些字段）</option>
+            <option value="allow">allow（只保留这些字段 + 必要字段）</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="text-xs text-muted-foreground block mb-1">use_defaults</label>
+          <select
+            value={rule.use_defaults ? 'true' : 'false'}
+            onChange={e => onChange({ ...rule, use_defaults: e.target.value === 'true' })}
+            className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground"
+          >
+            <option value="true">true（叠加内置默认过滤）</option>
+            <option value="false">false（仅使用自定义规则）</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <FieldEditor title="deny" values={rule.deny} onChange={deny => onChange({ ...rule, deny })} />
+        <FieldEditor title="allow" values={rule.allow} onChange={allow => onChange({ ...rule, allow })} />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        提示：配置键会同时匹配 <span className="font-mono">model</span>（别名）与上游原始模型名（original_model）。
+      </p>
+    </div>
+  );
+}
+
+export function ParameterFilterEditorDialog({
+  open,
+  onOpenChange,
+  availableModels,
+  initialConfig,
+  onSave,
+}: ParameterFilterEditorDialogProps) {
+  const [globalRule, setGlobalRule] = useState<FilterRule>(() => normalizeRule('all', {}));
+  const [modelRules, setModelRules] = useState<FilterRule[]>([]);
+
+  const modelOptions = useMemo(() => {
+    const set = new Set<string>();
+    (availableModels || []).forEach(m => {
+      const s = String(m || '').trim();
+      if (s) set.add(s);
+    });
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [availableModels]);
+
+  useEffect(() => {
+    if (!open) return;
+    const { globalRule, modelRules } = parseConfigToRules(initialConfig);
+    setGlobalRule(globalRule);
+    setModelRules(modelRules);
+  }, [open]);
+
+  const addModelRule = () => {
+    setModelRules(prev => {
+      const next = [...prev];
+      next.push({
+        modelKey: '',
+        enabled: true,
+        mode: 'deny',
+        use_defaults: true,
+        deny: [],
+        allow: [],
+      });
+      return next;
+    });
+  };
+
+  const updateModelRule = (idx: number, nextRule: FilterRule) => {
+    setModelRules(prev => {
+      const next = [...prev];
+      next[idx] = nextRule;
+      return next;
+    });
+  };
+
+  const deleteModelRule = (idx: number) => {
+    setModelRules(prev => prev.filter((_, i) => i !== idx));
+  };
+
+  const handleSave = () => {
+    // 基础校验：modelKey 不能为空
+    for (const r of modelRules) {
+      if (!String(r.modelKey || '').trim()) {
+        alert('存在空的模型名规则，请填写或删除。');
+        return;
+      }
+    }
+
+    const config = buildConfigFromRules(globalRule, modelRules);
+    onSave(config);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[90] animate-in fade-in duration-200" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-[980px] max-w-[96vw] max-h-[92vh] bg-background border border-border rounded-xl shadow-2xl z-[100] flex flex-col">
+          <div className="p-5 border-b border-border flex justify-between items-center bg-muted/30 flex-shrink-0">
+            <Dialog.Title className="text-lg font-bold text-foreground">请求体参数过滤 · 高级编辑器</Dialog.Title>
+            <Dialog.Close className="text-muted-foreground hover:text-foreground">
+              <X className="w-5 h-5" />
+            </Dialog.Close>
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-5 space-y-6">
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-foreground">全局规则（all）</h3>
+                <span className="text-xs text-muted-foreground">对所有模型生效（可被单模型规则叠加）</span>
+              </div>
+              <RuleCard rule={globalRule} availableModels={modelOptions} onChange={setGlobalRule} />
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-foreground">按模型规则</h3>
+                <button
+                  type="button"
+                  onClick={addModelRule}
+                  className="text-sm bg-primary/10 text-primary hover:bg-primary/20 px-3 py-2 rounded-lg"
+                >
+                  <Plus className="w-4 h-4 inline-block mr-1" /> 新增规则
+                </button>
+              </div>
+
+              {modelRules.length === 0 ? (
+                <div className="text-sm text-muted-foreground italic p-4 border border-dashed border-border rounded-lg text-center">
+                  暂无按模型规则，点击右上角“新增规则”。
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  {modelRules.map((r, idx) => (
+                    <RuleCard
+                      key={`${idx}-${r.modelKey}`}
+                      rule={r}
+                      availableModels={modelOptions}
+                      onChange={next => updateModelRule(idx, next)}
+                      onDelete={() => deleteModelRule(idx)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className="text-xs text-muted-foreground space-y-1">
+              <div>字段名支持 dot-path（例如 <span className="font-mono">stream_options.include_usage</span>）。</div>
+              <div>输出配置会写入 <span className="font-mono">provider.preferences.post_body_parameter_filter</span>。</div>
+            </section>
+          </div>
+
+          <div className="p-4 bg-muted/30 border-t border-border flex justify-end gap-3 flex-shrink-0">
+            <Dialog.Close className="px-4 py-2 text-sm font-medium text-foreground bg-muted hover:bg-muted/80 rounded-lg">取消</Dialog.Close>
+            <button
+              onClick={handleSave}
+              className="px-4 py-2 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 rounded-lg flex items-center gap-2"
+            >
+              <CheckCircle2 className="w-4 h-4" /> 保存规则
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,9 +3,59 @@ import { useAuthStore } from '../store/authStore';
 /**
  * 带鉴权与自动登出的 fetch。
  *
- * 约定：当后端返回 401/403 时，认为当前 token 已失效（常见于后端重启/更新后 JWT_SECRET 变更），
- * 前端将清除本地 token 并跳转到 /login。
+ * 说明：
+ * - 管理控制台使用 JWT（Authorization: Bearer <jwt>）。
+ * - 但部分接口会把“上游渠道/模型”的 401/403 透传回来（例如填错 OpenAI Key）。
+ *   这些 401/403 并不代表管理端 JWT 失效，不能因此把用户踢回登录页。
+ *
+ * 因此：
+ * - 仅当后端错误明确指向“本地鉴权失败”（token 缺失/失效/过期）时，才自动登出并跳转 /login。
  */
+
+function looksLikeLocalAuthFailure(detail: string): boolean {
+  const d = (detail || '').toLowerCase();
+  // core/auth.py、routes/auth.py 里常见的鉴权失败文案
+  return (
+    d.includes('invalid or missing credentials') ||
+    d.includes('invalid or expired token') ||
+    d.includes('not authenticated') ||
+    d.includes('could not validate credentials')
+  );
+}
+
+async function shouldAutoLogoutOnAuthError(res: Response): Promise<boolean> {
+  if (!(res.status === 401 || res.status === 403)) return false;
+
+  // 尽量从 body 中判断是否为“本地鉴权失败”；避免把上游 401/403 误判为 JWT 失效。
+  try {
+    const text = await res.clone().text();
+    if (!text) return false;
+
+    try {
+      const data = JSON.parse(text);
+
+      // FastAPI HTTPException: { detail: "..." }
+      if (data && typeof data === 'object') {
+        const detail = (data as any).detail;
+        if (typeof detail === 'string' && looksLikeLocalAuthFailure(detail)) return true;
+
+        // OpenAI 风格错误：{ error: { message: "..." } }
+        const err = (data as any).error;
+        if (err && typeof err === 'object') {
+          const msg = (err as any).message;
+          if (typeof msg === 'string' && looksLikeLocalAuthFailure(msg)) return true;
+        }
+      }
+    } catch {
+      // body 不是 JSON，就当作普通文本
+      if (looksLikeLocalAuthFailure(text)) return true;
+    }
+  } catch {
+    // ignore
+  }
+
+  return false;
+}
 export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
   const { token, logout } = useAuthStore.getState();
 
@@ -19,8 +69,8 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
     headers,
   });
 
-  // 统一处理：token 失效 / 权限不足
-  if (res.status === 401 || res.status === 403) {
+  // 统一处理：仅当“本地鉴权失败”时才自动登出。
+  if (await shouldAutoLogoutOnAuthError(res)) {
     try {
       logout();
     } catch {

--- a/frontend/src/pages/Channels.tsx
+++ b/frontend/src/pages/Channels.tsx
@@ -11,6 +11,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import * as Switch from '@radix-ui/react-switch';
 import { InterceptorSheet } from '../components/InterceptorSheet';
 import { ChannelTestDialog } from '../components/ChannelTestDialog';
+import { ApiKeyTestDialog } from '../components/ApiKeyTestDialog';
 
 // ========== Types ==========
 interface ApiKeyObj {
@@ -79,6 +80,8 @@ export default function Channels() {
   const [showPluginSheet, setShowPluginSheet] = useState(false);
   const [testDialogOpen, setTestDialogOpen] = useState(false);
   const [testingProvider, setTestingProvider] = useState<any>(null);
+  const [keyTestDialogOpen, setKeyTestDialogOpen] = useState(false);
+  const [keyTestInitialIndex, setKeyTestInitialIndex] = useState<number | null>(null);
   const [headersJson, setHeadersJson] = useState('');
   const [overridesJson, setOverridesJson] = useState('');
   const [modelDisplayKey, setModelDisplayKey] = useState(0);
@@ -532,6 +535,78 @@ export default function Channels() {
     setTestDialogOpen(true);
   };
 
+  const openKeyTestDialog = (initialIndex: number | null = null) => {
+    setKeyTestInitialIndex(initialIndex);
+    setKeyTestDialogOpen(true);
+  };
+
+  const buildProviderSnapshotForTest = (): any => {
+    if (!formData) return null;
+
+    const serializedKeys = formData.api_keys
+      .map(k => k.disabled ? `!${k.key.trim()}` : k.key.trim())
+      .filter(Boolean);
+    const finalApi = serializedKeys.length === 0 ? "" : serializedKeys.length === 1 ? serializedKeys[0] : serializedKeys;
+
+    const finalModels: any[] = [...formData.models];
+    formData.mappings.forEach(m => {
+      if (m.from && m.to) finalModels.push({ [m.to]: m.from });
+    });
+
+    let headersObj: any = undefined;
+    let overridesObj: any = undefined;
+    try {
+      if (headersJson.trim()) headersObj = JSON.parse(headersJson);
+    } catch {
+      headersObj = undefined;
+    }
+    try {
+      if (overridesJson.trim()) overridesObj = JSON.parse(overridesJson);
+    } catch {
+      overridesObj = undefined;
+    }
+
+    return {
+      provider: formData.provider,
+      base_url: formData.base_url,
+      model_prefix: formData.model_prefix || undefined,
+      api: finalApi,
+      model: finalModels,
+      engine: formData.engine || undefined,
+      enabled: formData.enabled,
+      groups: formData.groups,
+      preferences: {
+        ...formData.preferences,
+        headers: headersObj,
+        post_body_parameter_overrides: overridesObj,
+      },
+    };
+  };
+
+  const getProviderModelNameListForUi = (): string[] => {
+    if (!formData) return [];
+    // 这里提供“可请求的模型别名列表”，优先展示/返回别名。
+    const aliasMap = getAliasMap(); // upstream -> alias
+    const names: string[] = [];
+    // 1) 正常模型（字符串）
+    formData.models.forEach(upstream => {
+      const alias = aliasMap.get(upstream);
+      names.push(alias || upstream);
+    });
+    // 2) 映射中的 alias
+    formData.mappings.forEach(m => {
+      if (m.from) names.push(m.from);
+    });
+    return Array.from(new Set(names.map(s => String(s || '').trim()).filter(Boolean)));
+  };
+
+  const disableKeysInForm = (indices: number[]) => {
+    if (!formData || !indices.length) return;
+    const set = new Set(indices);
+    const next = formData.api_keys.map((k, idx) => set.has(idx) ? ({ ...k, disabled: true }) : k);
+    updateFormData('api_keys', next);
+  };
+
   const handleSave = async () => {
     if (!formData?.provider) {
       alert("渠道名称为必填项");
@@ -859,6 +934,14 @@ export default function Channels() {
                     <div className="flex items-center gap-2 text-xs">
                       <button onClick={copyAllKeys} className="text-muted-foreground hover:text-foreground flex items-center gap-1"><Copy className="w-3 h-3" /> 复制全部</button>
                       <button
+                        onClick={() => openKeyTestDialog(null)}
+                        disabled={formData.api_keys.length === 0}
+                        className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="测试该渠道中的全部 Key（可选自动禁用失效 Key）"
+                      >
+                        <Play className="w-3 h-3" /> 多key测试
+                      </button>
+                      <button
                         onClick={clearAllKeys}
                         disabled={formData.api_keys.length === 0}
                         className="text-red-600 dark:text-red-500 hover:text-red-700 dark:hover:text-red-400 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -883,6 +966,14 @@ export default function Channels() {
                         />
                         <button onClick={() => toggleKeyDisabled(idx)} className={keyObj.disabled ? 'text-muted-foreground' : 'text-emerald-500'} title={keyObj.disabled ? "启用" : "禁用"}>
                           {keyObj.disabled ? <ToggleLeft className="w-5 h-5" /> : <ToggleRight className="w-5 h-5" />}
+                        </button>
+                        <button
+                          onClick={() => openKeyTestDialog(idx)}
+                          disabled={!keyObj.key.trim()}
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="测试此 Key"
+                        >
+                          <Play className="w-4 h-4" />
                         </button>
                         <button onClick={() => deleteKey(idx)} className="text-red-500 hover:text-red-400 ml-1"><Trash2 className="w-4 h-4" /></button>
                       </div>
@@ -1154,7 +1245,23 @@ export default function Channels() {
           allPlugins={allPlugins}
           enabledPlugins={formData.preferences.enabled_plugins || []}
           providerPreferences={formData.preferences || {}}
+          providerModels={getProviderModelNameListForUi()}
           onUpdate={handlePluginSheetUpdate}
+        />
+      )}
+
+      {formData && (
+        <ApiKeyTestDialog
+          open={keyTestDialogOpen}
+          onOpenChange={setKeyTestDialogOpen}
+          title={`测试 API Keys: ${formData.provider || '未命名渠道'}`}
+          engine={formData.engine || 'openai'}
+          base_url={formData.base_url || ''}
+          provider_snapshot={buildProviderSnapshotForTest()}
+          apiKeys={formData.api_keys}
+          availableModels={getProviderModelNameListForUi()}
+          initialKeyIndex={keyTestInitialIndex}
+          onDisableKeys={disableKeysInForm}
         />
       )}
 

--- a/routes/channels.py
+++ b/routes/channels.py
@@ -312,13 +312,62 @@ async def test_channel(
     if model not in model_dict:
         raise HTTPException(status_code=400, detail=f"model '{model}' 不在当前渠道模型配置中")
 
-    # 构建测试请求
-    test_request = RequestModel(
-        model=model,
-        messages=[{"role": "user", "content": "Hi"}],
-        max_tokens=1000,
-        stream=False,
-    )
+    # 构建测试请求（允许外部覆盖部分参数，便于做 Key/流式等测试）
+    # 注意：这里尽量保持「轻量」请求，避免测试时产生较大消耗。
+    import asyncio
+
+    prompt = test_config.get("prompt") or test_config.get("text") or "Hi"
+    raw_messages = test_config.get("messages")
+    if isinstance(raw_messages, list) and raw_messages:
+        messages = raw_messages
+    else:
+        messages = [{"role": "user", "content": str(prompt)}]
+
+    request_patch = test_config.get("request_patch")
+    if not isinstance(request_patch, dict):
+        request_patch = {}
+
+    # 常用字段（显式字段优先级 > request_patch > 默认值）
+    def _get_first(*keys: str, default=None):
+        for k in keys:
+            if k in test_config and test_config.get(k) is not None:
+                return test_config.get(k)
+        if keys and keys[0] in request_patch and request_patch.get(keys[0]) is not None:
+            return request_patch.get(keys[0])
+        return default
+
+    stream = bool(_get_first("stream", default=False))
+
+    # 默认 max_tokens 设小一点即可验证可用性
+    max_tokens = _get_first("max_tokens", default=16)
+    try:
+        max_tokens = int(max_tokens) if max_tokens is not None else None
+    except Exception:
+        max_tokens = 16
+
+    temperature = _get_first("temperature", default=0.5)
+    try:
+        temperature = float(temperature) if temperature is not None else None
+    except Exception:
+        temperature = 0.5
+
+    top_p = _get_first("top_p", default=1.0)
+    try:
+        top_p = float(top_p) if top_p is not None else None
+    except Exception:
+        top_p = 1.0
+
+    # 允许额外字段透传（RequestModel extra=allow）
+    test_request_payload = {
+        **request_patch,
+        "model": model,
+        "messages": messages,
+        "stream": stream,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    test_request = RequestModel(**test_request_payload)
 
     # 获取代理配置（优先级：test_config > provider > global）
     proxy = test_config.get("proxy")
@@ -354,15 +403,78 @@ async def test_channel(
             logger.info(f"Channel test - Payload (truncated): {pretty_payload[:2000]}")
         
         async with app.state.client_manager.get_client(url, proxy) as client:
+            # stream 测试：只读取少量响应以验证链路，不让测试请求卡住
+            if stream:
+                async with client.stream(
+                    "POST",
+                    url,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout,
+                ) as response:
+                    latency_ms = int((time() - start_time) * 1000)
+
+                    upstream_status_code = int(response.status_code)
+                    auth_failed = upstream_status_code in (401, 403)
+
+                    preview = ""
+                    try:
+                        it = response.aiter_text()
+                        preview = await asyncio.wait_for(it.__anext__(), timeout=min(10, timeout))
+                        preview = (preview or "")[:800]
+                    except StopAsyncIteration:
+                        preview = ""
+                    except Exception as e:
+                        preview = f"<stream preview failed: {type(e).__name__}: {e}>"[:800]
+
+                    if 200 <= upstream_status_code < 300:
+                        return JSONResponse(
+                            content={
+                                "success": True,
+                                "latency_ms": latency_ms,
+                                "message": "测试成功",
+                                "upstream_status_code": upstream_status_code,
+                                "auth_failed": auth_failed,
+                                "stream": True,
+                                "response_preview": preview,
+                            }
+                        )
+
+                    # 尝试读取错误文本（避免读太多）
+                    err_text = ""
+                    try:
+                        err_text = (await response.aread()).decode("utf-8", errors="ignore")[:800]
+                    except Exception:
+                        err_text = ""
+                    if not err_text:
+                        err_text = f"HTTP {upstream_status_code}"
+
+                    return JSONResponse(
+                        status_code=200,
+                        content={
+                            "success": False,
+                            "latency_ms": latency_ms,
+                            "message": f"HTTP {upstream_status_code}",
+                            "error": err_text,
+                            "upstream_status_code": upstream_status_code,
+                            "auth_failed": auth_failed,
+                            "stream": True,
+                            "response_preview": preview,
+                        },
+                    )
+
+            # 非 stream：正常 post 并解析 JSON
             response = await client.post(
                 url,
                 headers=headers,
                 json=payload,
-                timeout=timeout
+                timeout=timeout,
             )
-            
+
             latency_ms = int((time() - start_time) * 1000)
-            
+            upstream_status_code = int(response.status_code)
+            auth_failed = upstream_status_code in (401, 403)
+
             # 统一解析响应体
             resp_json = None
             error_detail = ""
@@ -370,7 +482,7 @@ async def test_channel(
                 resp_json = response.json()
             except Exception:
                 resp_json = None
-            
+
             if isinstance(resp_json, dict):
                 if resp_json.get("error") is not None:
                     err_obj = resp_json.get("error")
@@ -385,36 +497,44 @@ async def test_channel(
                         error_detail = str(err_obj)
                 elif resp_json.get("detail") and not resp_json.get("choices"):
                     error_detail = str(resp_json.get("detail"))
-            
+
             if not error_detail:
                 try:
                     body_text = response.text
                     if body_text and body_text.strip() and response.status_code >= 400:
-                        error_detail = body_text[:500]
+                        error_detail = body_text[:800]
                 except Exception:
                     pass
-            
-            is_success = 200 <= response.status_code < 300 and not error_detail
-            
+
+            is_success = 200 <= upstream_status_code < 300 and not error_detail
+
             if is_success:
-                return JSONResponse(content={
-                    "success": True,
-                    "latency_ms": latency_ms,
-                    "message": "测试成功"
-                })
-            else:
-                if not error_detail:
-                    error_detail = f"HTTP {response.status_code}"
-                
                 return JSONResponse(
-                    status_code=200,
                     content={
-                        "success": False,
+                        "success": True,
                         "latency_ms": latency_ms,
-                        "message": f"HTTP {response.status_code}",
-                        "error": error_detail
+                        "message": "测试成功",
+                        "upstream_status_code": upstream_status_code,
+                        "auth_failed": auth_failed,
+                        "stream": False,
                     }
                 )
+
+            if not error_detail:
+                error_detail = f"HTTP {upstream_status_code}"
+
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "success": False,
+                    "latency_ms": latency_ms,
+                    "message": f"HTTP {upstream_status_code}",
+                    "error": error_detail,
+                    "upstream_status_code": upstream_status_code,
+                    "auth_failed": auth_failed,
+                    "stream": False,
+                },
+            )
                 
     except httpx.TimeoutException:
         latency_ms = int((time() - start_time) * 1000)
@@ -424,7 +544,10 @@ async def test_channel(
                 "success": False,
                 "latency_ms": latency_ms,
                 "message": "请求超时",
-                "error": f"请求超时（{timeout}秒）"
+                "error": f"请求超时（{timeout}秒）",
+                "upstream_status_code": None,
+                "auth_failed": False,
+                "stream": bool(stream),
             }
         )
     except httpx.ConnectError as e:
@@ -434,7 +557,10 @@ async def test_channel(
                 "success": False,
                 "latency_ms": None,
                 "message": "连接失败",
-                "error": str(e)
+                "error": str(e),
+                "upstream_status_code": None,
+                "auth_failed": False,
+                "stream": bool(stream),
             }
         )
     except Exception as e:
@@ -464,7 +590,10 @@ async def test_channel(
                 "success": False,
                 "latency_ms": latency_ms,
                 "message": "测试失败",
-                "error": error_message
+                "error": error_message,
+                "upstream_status_code": None,
+                "auth_failed": False,
+                "stream": bool(stream),
             }
         )
 


### PR DESCRIPTION
- 新增渠道 API Key 测试功能（单个/批量，一键禁用失效 Key）
- 参数过滤插件优化 UI，新增根据模型单独设置参数过滤功能
- fix：渠道“获取模型失败”（上游 401/403）时，不会跳登录页，会在当前页面弹出/显示错误信息
- fix: 修复 Claude（Anthropic）渠道在 Base URL 填 /v1/messages 时无法“拉取模型”的问题