### PR TITLE
Feat/compact endpoint support clean

### DIFF
--- a/core/dialects/openai_responses.py
+++ b/core/dialects/openai_responses.py
@@ -530,6 +530,50 @@ async def responses_handler(
     )
 
 
+async def responses_compact_handler(
+    request: "Request",
+    background_tasks: "BackgroundTasks",
+    api_index: int,
+    **kwargs,
+):
+    """
+    OpenAI Responses compact endpoint - POST /v1/responses/compact
+
+    Compact is a native Responses auxiliary endpoint.  Keep the original payload
+    for upstream passthrough and only build a minimal RequestModel for auth,
+    rate limit, model routing, and provider selection.
+    """
+    from core.error_response import openai_error_response
+    from routes.deps import get_model_handler
+
+    try:
+        native_body: Dict[str, Any] = await request.json()
+    except Exception:
+        native_body = {}
+
+    model = native_body.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return openai_error_response("Missing required parameter: model", 400)
+
+    request_model = RequestModel(
+        model=model.strip(),
+        messages=[Message(role="user", content="")],
+        stream=False,
+    )
+
+    model_handler = get_model_handler()
+    return await model_handler.request_model(
+        request_model,
+        api_index,
+        background_tasks,
+        endpoint=request.url.path,
+        dialect_id="openai-responses",
+        original_payload=native_body,
+        original_headers=dict(request.headers),
+        passthrough_only=True,
+    )
+
+
 # ============================================================
 # 注册
 # ============================================================
@@ -555,6 +599,16 @@ def register() -> None:
                     tags=["Responses"],
                     summary="Create Response",
                     description="创建响应请求，兼容 OpenAI Responses API 格式（GPT-5/o1/o3 等新模型）",
+                ),
+                EndpointDefinition(
+                    path="/v1/responses/compact",
+                    methods=["POST"],
+                    handler=responses_compact_handler,
+                    tags=["Responses"],
+                    summary="Compact Response",
+                    description="原生透传 OpenAI Responses compact 请求，仅支持 openai-responses provider",
+                    passthrough_only=True,
+                    passthrough_root="/v1/responses",
                 ),
             ],
         )

--- a/core/handler.py
+++ b/core/handler.py
@@ -670,8 +670,18 @@ async def process_request_passthrough(
         original_model=original_model,
     )
 
-    # 渠道级透传 payload 修饰（把“渠道特殊逻辑”收敛在各自 channel 文件内）
-    if channel and getattr(channel, "passthrough_payload_adapter", None):
+    # 渠道级透传 payload 修饰（把“渠道特殊逻辑”收敛在各自 channel 文件内）。
+    # Responses compact 是原生辅助端点，必须保留 compact 请求语义，不应用普通
+    # /v1/responses 的 system/instructions/store=false 兼容 patch。
+    skip_passthrough_payload_adapter = (
+        passthrough_ctx.dialect_id == "openai-responses"
+        and endpoint == "/v1/responses/compact"
+    )
+    if (
+        channel
+        and getattr(channel, "passthrough_payload_adapter", None)
+        and not skip_passthrough_payload_adapter
+    ):
         payload = await channel.passthrough_payload_adapter(
             payload,
             passthrough_ctx.modifications,

--- a/test/dialects/test_dialects.py
+++ b/test/dialects/test_dialects.py
@@ -1,12 +1,72 @@
 import asyncio
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import httpx
+from fastapi import BackgroundTasks, FastAPI
+from fastapi.testclient import TestClient
 
 from core.dialects.gemini import parse_gemini_request, render_gemini_response
 from core.dialects.claude import parse_claude_request
 from core.dialects.passthrough import detect_passthrough, apply_passthrough_modifications
+from core.models import RequestModel, Message
 
 
 def run(coro):
     return asyncio.run(coro)
+
+
+def _compact_test_app():
+    from core.dialects import dialect_router
+
+    app = FastAPI()
+    app.state.global_rate_limit = [(9999, 60)]
+    app.state.api_list = ["test-key"]
+    app.state.api_keys_db = [{"role": "user"}]
+    app.include_router(dialect_router)
+    return app
+
+
+async def _read_response_json(response):
+    chunks = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8")
+        chunks.append(chunk)
+    return json.loads(b"".join(chunks).decode("utf-8"))
+
+
+def _handler_app_state(client_manager):
+    return SimpleNamespace(
+        config={"preferences": {"max_retry_count": 1}},
+        provider_timeouts={"global": {}, "provider1": {}, "provider2": {}},
+        keepalive_interval={"global": {}, "provider1": {}, "provider2": {}},
+        client_manager=client_manager,
+        channel_manager=SimpleNamespace(cooldown_period=0),
+        error_triggers={},
+    )
+
+
+class RaisingClientManager:
+    @asynccontextmanager
+    async def get_client(self, base_url, proxy=None):
+        raise AssertionError(f"unexpected upstream request to {base_url}")
+        yield
+
+
+class MockClientManager:
+    def __init__(self, handler):
+        self.handler = handler
+
+    @asynccontextmanager
+    async def get_client(self, base_url, proxy=None):
+        async with httpx.AsyncClient(transport=httpx.MockTransport(self.handler)) as client:
+            yield client
+
+
+async def _noop_update_stats(*args, **kwargs):
+    return None
 
 
 def test_gemini_parse_simple_text():
@@ -178,3 +238,155 @@ def test_openai_responses_parse_instructions():
     assert canonical.messages[0].role == "system"
     assert canonical.messages[0].content == "You are a helpful assistant."
     assert canonical.messages[1].role == "user"
+
+
+def test_openai_responses_compact_no_auth_enters_auth_layer():
+    app = _compact_test_app()
+
+    with TestClient(app) as client:
+        response = client.post("/v1/responses/compact", json={"model": "gpt-5"})
+
+    assert response.status_code == 403
+    assert response.status_code not in (404, 405)
+
+
+def test_openai_responses_compact_requires_model():
+    app = _compact_test_app()
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/responses/compact",
+            json={"input": []},
+            headers={"Authorization": "Bearer test-key"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "model" in response.json()["error"]["message"]
+
+
+def test_openai_responses_compact_rejects_non_responses_provider_before_upstream():
+    from core.handler import ModelRequestHandler
+
+    request_info = {"request_id": "req-test", "api_key": "test-key"}
+    app = SimpleNamespace(state=_handler_app_state(RaisingClientManager()))
+    handler = ModelRequestHandler(app, lambda: request_info, _noop_update_stats, default_timeout=30)
+    provider = {
+        "provider": "provider1",
+        "engine": "openai",
+        "_model_dict_cache": {"gpt-5": "gpt-5"},
+        "preferences": {},
+    }
+
+    response = run(handler.request_model(
+        RequestModel(model="gpt-5", messages=[Message(role="user", content="")], stream=False),
+        api_index=0,
+        background_tasks=BackgroundTasks(),
+        endpoint="/v1/responses/compact",
+        dialect_id="openai-responses",
+        original_payload={"model": "gpt-5"},
+        original_headers={},
+        passthrough_only=True,
+        override_providers=[provider],
+    ))
+
+    assert response.status_code == 501
+    assert "requires passthrough mode" in response.body.decode("utf-8")
+
+
+def test_openai_responses_compact_passthrough_uses_custom_base_url_and_raw_payload():
+    from core.handler import ModelRequestHandler
+
+    captured = {}
+
+    def upstream_handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={"object": "response.compaction", "id": "cmp_123", "status": "completed"},
+        )
+
+    request_info = {"request_id": "req-test", "api_key": "test-key"}
+    app = SimpleNamespace(state=_handler_app_state(MockClientManager(upstream_handler)))
+    handler = ModelRequestHandler(app, lambda: request_info, _noop_update_stats, default_timeout=30)
+    provider = {
+        "provider": "provider1",
+        "engine": "openai-responses",
+        "base_url": "https://proxy.example/custom/v1",
+        "_model_dict_cache": {"alias-model": "gpt-5-real"},
+        "preferences": {
+            "system_prompt": "SHOULD_NOT_BE_INJECTED",
+            "post_body_parameter_overrides": {
+                "all": {"metadata": {"tenant": "test"}}
+            },
+        },
+    }
+    original_payload = {
+        "model": "alias-model",
+        "input": [{"role": "system", "content": "keep-as-input"}],
+        "max_tokens": 123,
+    }
+
+    response = run(handler.request_model(
+        RequestModel(model="alias-model", messages=[Message(role="user", content="")], stream=False),
+        api_index=0,
+        background_tasks=BackgroundTasks(),
+        endpoint="/v1/responses/compact",
+        dialect_id="openai-responses",
+        original_payload=original_payload,
+        original_headers={"authorization": "Bearer client-key"},
+        passthrough_only=True,
+        override_providers=[provider],
+    ))
+    body = run(_read_response_json(response))
+
+    assert response.status_code == 200
+    assert body == {"object": "response.compaction", "id": "cmp_123", "status": "completed"}
+    assert captured["url"] == "https://proxy.example/custom/v1/responses/compact"
+    assert captured["payload"]["model"] == "gpt-5-real"
+    assert captured["payload"]["input"] == original_payload["input"]
+    assert captured["payload"]["max_tokens"] == 123
+    assert captured["payload"]["metadata"] == {"tenant": "test"}
+    assert "instructions" not in captured["payload"]
+    assert "store" not in captured["payload"]
+
+
+def test_openai_responses_compact_passthrough_preserves_upstream_error_status():
+    from core.handler import ModelRequestHandler
+
+    captured = {}
+
+    def upstream_handler(request: httpx.Request) -> httpx.Response:
+        captured["called"] = True
+        return httpx.Response(
+            401,
+            json={"error": {"message": "upstream auth failed", "type": "invalid_request_error"}},
+        )
+
+    request_info = {"request_id": "req-test", "api_key": "test-key"}
+    app = SimpleNamespace(state=_handler_app_state(MockClientManager(upstream_handler)))
+    handler = ModelRequestHandler(app, lambda: request_info, _noop_update_stats, default_timeout=30)
+    provider = {
+        "provider": "provider1",
+        "engine": "openai-responses",
+        "base_url": "https://proxy.example/v1",
+        "_model_dict_cache": {"gpt-5": "gpt-5"},
+        "preferences": {},
+    }
+
+    response = run(handler.request_model(
+        RequestModel(model="gpt-5", messages=[Message(role="user", content="")], stream=False),
+        api_index=0,
+        background_tasks=BackgroundTasks(),
+        endpoint="/v1/responses/compact",
+        dialect_id="openai-responses",
+        original_payload={"model": "gpt-5"},
+        original_headers={},
+        passthrough_only=True,
+        override_providers=[provider],
+    ))
+
+    assert captured["called"] is True
+    assert response.status_code == 401
+    assert "upstream auth failed" in response.body.decode("utf-8")


### PR DESCRIPTION
- 新增 POST /v1/responses/compact，仅支持 openai-responses provider 的原生 passthrough；保留 compact 原始请求语义，不复用普通 /v1/responses 的 payload patch
- 增加 compact 路由与 passthrough 测试覆盖