### PR TITLE
fix(streaming): 默认启用 SSE keepalive 并合并普通与透传流式保活实现

### DIFF
--- a/core/handler.py
+++ b/core/handler.py
@@ -316,6 +316,30 @@ def get_preference(
     return timeout_value
 
 
+def normalize_keepalive_interval(keepalive_interval: Any, timeout_value: Any) -> Optional[int]:
+    """把 keepalive_interval 规范化为可用于 SSE 心跳的正整数秒数。"""
+    # 修改原因：keepalive_interval 来自配置库，可能缺失、为 0/负数、字符串，或大于请求超时。
+    # 修改方式：集中转换和边界检查，只有正整数且小于请求超时时才启用。
+    # 目的：避免无效配置触发热循环/无意义心跳，同时让默认 15 秒心跳稳定生效。
+    try:
+        interval = int(keepalive_interval)
+    except (TypeError, ValueError):
+        return None
+
+    if interval <= 0:
+        return None
+
+    try:
+        timeout = int(timeout_value)
+    except (TypeError, ValueError):
+        timeout = 0
+
+    if timeout > 0 and interval >= timeout:
+        return None
+
+    return interval
+
+
 class ModelRequestHandler:
     """
     模型请求处理器
@@ -698,8 +722,7 @@ class ModelRequestHandler:
                 self.app.state.keepalive_interval, provider_name, 
                 original_request_model, 99999
             )
-            if keepalive_interval > local_timeout_value:
-                keepalive_interval = None
+            keepalive_interval = normalize_keepalive_interval(keepalive_interval, local_timeout_value)
             if is_local_api_key(provider_name):
                 keepalive_interval = None
 

--- a/core/passthrough.py
+++ b/core/passthrough.py
@@ -21,7 +21,7 @@ from core.request import get_payload
 from core.response import check_response
 from core.streaming import LoggingStreamingResponse
 from core.utils import get_engine, is_local_api_key, provider_api_circular_list
-from utils import apply_custom_headers, has_header_case_insensitive, safe_get, wait_for_timeout
+from utils import apply_custom_headers, has_header_case_insensitive, safe_get, wait_for_timeout, iter_sse_with_keepalive
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -213,34 +213,23 @@ async def _passthrough_error_wrapper(generator, channel_id, keepalive_interval: 
             yield first
 
         if keepalive_interval:
-            # 修改原因：透传流同样可能在首包前或两次事件之间长时间静默。
-            # 修改方式：复用 wait_for_timeout 的单飞 __anext__ 任务，超时只发 SSE 注释帧，不并发拉取上游。
-            # 目的：不解析/改写透传协议内容的前提下，为下游连接提供稳定空闲字节。
-            if emit_initial_keepalive:
-                yield ": keepalive\n\n"
-            while True:
-                try:
-                    item, status = await wait_for_timeout(gen, timeout=keepalive_interval, wait_task=wait_task)
-                    if status == "timeout":
-                        wait_task = item
-                        yield ": keepalive\n\n"
-                        continue
-                    if status == "reentrant":
-                        wait_task = None
-                        await asyncio.sleep(keepalive_interval)
-                        yield ": keepalive\n\n"
-                        continue
-                    wait_task = None
-                    yield item
-                except asyncio.CancelledError:
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    logger.debug(f"provider: {channel_id:<11} passthrough stream cancelled by client")
-                    return
-                except StopAsyncIteration:
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    return
+            # 修改原因：透传 keepalive 此前是独立复制的一份 pump，与 utils 中的实现重复，
+            #   keepalive 帧样式与挂起任务清理需要两处同步维护。
+            # 修改方式：改调 utils.iter_sse_with_keepalive 共用同一套保活循环；不传 transform，
+            #   保持透传“不解析/不改写协议内容”的约束，仅注入 SSE 注释帧。上游 EOF 由该函数内部
+            #   转为正常结束，挂起的 __anext__ 任务也在其 finally 中统一清理。
+            # 目的：消除重复实现，统一 keepalive 帧样式与保活语义。
+            try:
+                async for chunk in iter_sse_with_keepalive(
+                    gen,
+                    interval=keepalive_interval,
+                    wait_task=wait_task,
+                    emit_initial=emit_initial_keepalive,
+                ):
+                    yield chunk
+            except asyncio.CancelledError:
+                logger.debug(f"provider: {channel_id:<11} passthrough stream cancelled by client")
+                return
         else:
             async for chunk in gen:
                 yield chunk

--- a/core/passthrough.py
+++ b/core/passthrough.py
@@ -21,7 +21,7 @@ from core.request import get_payload
 from core.response import check_response
 from core.streaming import LoggingStreamingResponse
 from core.utils import get_engine, is_local_api_key, provider_api_circular_list
-from utils import apply_custom_headers, has_header_case_insensitive, safe_get
+from utils import apply_custom_headers, has_header_case_insensitive, safe_get, wait_for_timeout
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -150,12 +150,12 @@ async def _fetch_passthrough_response(client, url, headers, payload, timeout, en
     yield result
 
 
-async def _passthrough_error_wrapper(generator, channel_id):
+async def _passthrough_error_wrapper(generator, channel_id, keepalive_interval: Optional[int] = None):
     """
-    透传模式的简单错误包装器
-    
-    只检测 HTTP 错误（由 check_response 完成），不做 JSON 解析
-    直接透传所有内容
+    透传模式的简单错误包装器。
+
+    - 只检测 HTTP 错误（由 check_response 完成），不做 JSON 解析。
+    - 对 SSE 透传流注入注释帧 keepalive，保持与普通流式路径一致的空闲保活语义。
     """
     from time import time as time_now
     start_time = time_now()
@@ -204,20 +204,60 @@ async def _passthrough_error_wrapper(generator, channel_id):
             
             yield chunk
     
-    # 透传模式：直接获取第一个 chunk，不做额外过滤
-    # SSE 流的内容（如 event:, data:）都是有效内容，不应该被跳过
+    # 透传模式：直接获取第一个 chunk，不做额外过滤。
+    # SSE 流的内容（如 event:, data:）都是有效内容，不应该被跳过。
     gen = wrapped()
+
+    async def final_gen(first=None, wait_task=None, emit_initial_keepalive: bool = False):
+        if first is not None:
+            yield first
+
+        if keepalive_interval:
+            # 修改原因：透传流同样可能在首包前或两次事件之间长时间静默。
+            # 修改方式：复用 wait_for_timeout 的单飞 __anext__ 任务，超时只发 SSE 注释帧，不并发拉取上游。
+            # 目的：不解析/改写透传协议内容的前提下，为下游连接提供稳定空闲字节。
+            if emit_initial_keepalive:
+                yield ": keepalive\n\n"
+            while True:
+                try:
+                    item, status = await wait_for_timeout(gen, timeout=keepalive_interval, wait_task=wait_task)
+                    if status == "timeout":
+                        wait_task = item
+                        yield ": keepalive\n\n"
+                        continue
+                    if status == "reentrant":
+                        wait_task = None
+                        await asyncio.sleep(keepalive_interval)
+                        yield ": keepalive\n\n"
+                        continue
+                    wait_task = None
+                    yield item
+                except asyncio.CancelledError:
+                    if wait_task is not None and not wait_task.done():
+                        wait_task.cancel()
+                    logger.debug(f"provider: {channel_id:<11} passthrough stream cancelled by client")
+                    return
+                except StopAsyncIteration:
+                    if wait_task is not None and not wait_task.done():
+                        wait_task.cancel()
+                    return
+        else:
+            async for chunk in gen:
+                yield chunk
+
     try:
-        first = await gen.__anext__()
+        if keepalive_interval:
+            first, status = await wait_for_timeout(gen, timeout=keepalive_interval)
+            if status == "timeout":
+                return final_gen(wait_task=first, emit_initial_keepalive=True), 3.1415
+            if status == "reentrant":
+                return final_gen(emit_initial_keepalive=True), 3.1415
+        else:
+            first = await gen.__anext__()
     except StopAsyncIteration:
         raise HTTPException(status_code=502, detail="Upstream server returned an empty response.")
     
-    async def final_gen():
-        yield first
-        async for chunk in gen:
-            yield chunk
-    
-    return final_gen(), first_response_time or (time_now() - start_time)
+    return final_gen(first=first), first_response_time or (time_now() - start_time)
 
 
 async def process_request_passthrough(
@@ -426,7 +466,7 @@ async def process_request_passthrough(
                     )
                 # 使用简单的透传错误包装器，不做 JSON 解析
                 wrapped_generator, first_response_time = await _passthrough_error_wrapper(
-                    generator, channel_id
+                    generator, channel_id, keepalive_interval=keepalive_interval
                 )
 
                 if client_wants_stream:

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -505,7 +505,7 @@ export default function Settings() {
                 <label className="text-sm font-medium text-foreground mb-1.5 block">Keepalive 心跳间隔 (秒)</label>
                 <input
                   type="number" min="0" max="300"
-                  value={preferences.keepalive_interval?.default ?? 25}
+                  value={preferences.keepalive_interval?.default ?? 15}
                   onChange={e => updatePreference('keepalive_interval', { ...(preferences.keepalive_interval || {}), default: parseInt(e.target.value) })}
                   className="w-full bg-background border border-border px-3 py-2 rounded-lg text-sm text-foreground"
                 />

--- a/main.py
+++ b/main.py
@@ -45,6 +45,10 @@ from core.stats import (
 from core.plugins import get_plugin_manager
 
 DEFAULT_TIMEOUT = int(os.getenv("TIMEOUT", 600))
+# 修改原因：SSE 流式响应在上游长时间思考/检索/排队时需要应用层心跳，不能依赖 TCP/Nginx keepalive。
+# 修改方式：为 keepalive_interval 提供可环境变量覆盖的合理默认值，配置文件仍可按全局/渠道/模型覆盖。
+# 目的：默认每 15 秒向下游发送 SSE 注释帧，避免客户端或中间代理因空闲无字节而断开。
+DEFAULT_KEEPALIVE_INTERVAL = int(os.getenv("KEEPALIVE_INTERVAL", 15))
 # DEBUG 环境变量支持 true/false/1/0/yes/no
 is_debug = env_bool("DEBUG", False)
 logger.info("DISABLE_DATABASE: %s", DISABLE_DATABASE)
@@ -60,17 +64,20 @@ logger.info("VERSION: %s", VERSION)
 
 def init_preference(all_config, preference_key, default_timeout=DEFAULT_TIMEOUT):
     # 存储超时配置
-    preference_dict = {}
+    # 修改原因：旧逻辑在 preferences 为空或未声明某项偏好时，会让 global 默认值变成空 dict，
+    # 后续调用方若传入兜底值就可能覆盖启动期 default_timeout（keepalive 因此默认落到 99999 并被禁用）。
+    # 修改方式：先写入 default_timeout，再叠加配置文件中的全局/模型级覆盖。
+    # 目的：让 model_timeout、keepalive_interval 等偏好都稳定遵守启动期默认值，同时保留现有覆盖语义。
+    preference_dict = {"default": default_timeout}
     preferences = safe_get(all_config, "preferences", default={})
     providers = safe_get(all_config, "providers", default=[])
     if preferences:
         if isinstance(preferences.get(preference_key), int):
             preference_dict["default"] = preferences.get(preference_key)
         else:
-            for model_name, timeout_value in preferences.get(preference_key, {"default": default_timeout}).items():
+            preference_settings = preferences.get(preference_key, {}) or {}
+            for model_name, timeout_value in preference_settings.items():
                 preference_dict[model_name] = timeout_value
-            if "default" not in preferences.get(preference_key, {}):
-                preference_dict["default"] = default_timeout
 
     result = defaultdict(lambda: defaultdict(lambda: default_timeout))
     for provider in providers:
@@ -483,7 +490,7 @@ async def lifespan(app: FastAPI):
                     app.state.admin_api_key = [app.state.api_keys_db[0].get("api")]
 
         app.state.provider_timeouts = init_preference(app.state.config, "model_timeout", DEFAULT_TIMEOUT)
-        app.state.keepalive_interval = init_preference(app.state.config, "keepalive_interval", 99999)
+        app.state.keepalive_interval = init_preference(app.state.config, "keepalive_interval", DEFAULT_KEEPALIVE_INTERVAL)
         # 初始化 models_list（用于存储从其他 API Key 引用的模型列表）
         app.state.models_list = {}
         # pprint(dict(app.state.provider_timeouts))

--- a/utils.py
+++ b/utils.py
@@ -1044,6 +1044,79 @@ async def wait_for_timeout(wait_for_thing, timeout = 3, wait_task=None):
     else:
         return first_response_task, "timeout"
 
+
+# SSE keepalive 注释帧。SSE 规范规定以 ":" 开头的行是注释，客户端必须忽略，
+# 因此可安全用于空闲保活，且不会污染 OpenAI/Claude/Gemini 任一方言的事件语义。
+SSE_KEEPALIVE_COMMENT = ": keepalive\n\n"
+
+
+async def iter_sse_with_keepalive(
+    generator,
+    interval,
+    *,
+    wait_task=None,
+    emit_initial=False,
+    transform=None,
+):
+    """统一的 SSE keepalive 注入循环，供普通流式与透传流式共用。
+
+    修改原因：error_handling_wrapper 与 core/passthrough 此前各自复制了一份几乎相同的
+      keepalive pump（wait_for_timeout -> 超时发注释帧 -> 命中则产出 item），keepalive
+      帧样式与重入/取消清理逻辑分散，容易改一处漏一处。
+    修改方式：抽出唯一的 pump 实现，把「是否对 item 做协议转换」通过 transform 注入；
+      其余 keepalive 固有逻辑（单飞 __anext__、超时/重入退避、上游 EOF 收尾、finally
+      清理挂起 wait_task）集中于此。
+    目的：两条路径复用同一套 keepalive 帧与保活语义，并顺带修复生成器被关闭时挂起的
+      wait_task 泄漏。
+
+    职责边界：只处理 keepalive 循环本身；网络错误、done_message、reset_client、
+      stream_end 日志等业务语义不在此处理，相关异常会原样向调用方传播，由各路径自行收尾。
+
+    参数：
+    - generator: 上游异步生成器。
+    - interval: 心跳间隔秒数（即 wait_for_timeout 的 timeout）。
+    - wait_task: 首包阶段已创建、尚未完成的 __anext__ 任务，复用以避免并发拉取上游。
+    - emit_initial: 进入循环前是否立即补发一帧（首包尚未到达时为 True）。
+    - transform: 可选 async 转换器，仅作用于真实 item（不作用于注释帧）；普通流式传入
+      ensure_string 包装，透传流式不传以保持「不解析/不改写协议内容」。
+    """
+    if emit_initial:
+        yield SSE_KEEPALIVE_COMMENT
+    try:
+        while True:
+            try:
+                item, status = await wait_for_timeout(generator, timeout=interval, wait_task=wait_task)
+            except StopAsyncIteration:
+                # 上游 EOF：正常结束循环，交由 finally 统一清理
+                return
+            except RuntimeError as e:
+                # 极端时序仍可能抛重入错误：退避后补一帧，不打断主循环
+                if "asynchronous generator is already running" in str(e):
+                    wait_task = None
+                    await asyncio.sleep(0.2)
+                    yield SSE_KEEPALIVE_COMMENT
+                    continue
+                raise
+            if status == "timeout":
+                # 复用仍在运行的 __anext__ 任务，避免并发创建导致重入
+                wait_task = item
+                yield SSE_KEEPALIVE_COMMENT
+                continue
+            if status == "reentrant":
+                # 重入：按心跳周期退避，避免刷屏
+                wait_task = None
+                await asyncio.sleep(interval)
+                yield SSE_KEEPALIVE_COMMENT
+                continue
+            wait_task = None
+            yield (await transform(item)) if transform is not None else item
+    finally:
+        # 无论因 EOF、异常还是被消费者关闭（GeneratorExit）退出，都取消仍挂起的
+        # 单飞 __anext__ 任务，避免连接资源泄漏。
+        if wait_task is not None and not wait_task.done():
+            wait_task.cancel()
+
+
 async def error_handling_wrapper(
     generator,
     channel_id,
@@ -1079,94 +1152,63 @@ async def error_handling_wrapper(
 
         # 如果需要心跳机制但不使用嵌套生成器方式
         if with_keepalive:
-            # 修改原因：旧实现只在首包超时时进入 keepalive 分支，因此首包成功后 chunk 间静默不会再发心跳。
-            # 修改方式：允许首包成功后也复用同一个等待循环；只有首包尚未到达时才立即补一个心跳。
-            # 目的：覆盖“上游已经开始 stream 但中途长时间不吐字”的真实空闲场景。
-            if first_item is None:
-                yield ": keepalive\n\n"
-            while True:
+            # 修改原因：此前 keepalive pump 在本函数与 core/passthrough 各复制了一份，
+            #   keepalive 帧样式、重入退避和挂起任务清理容易改一处漏一处。
+            # 修改方式：统一改调 iter_sse_with_keepalive，本分支只保留普通流式特有的业务收尾
+            #   （网络错误发 done、reset_client、stream_end 日志）；用 ensure_string 作为 transform
+            #   注入协议转换，首包尚未到达时通过 emit_initial 补发首帧。挂起的 __anext__ 任务由
+            #   iter_sse_with_keepalive 的 finally 统一清理，本分支不再各自 cancel。
+            # 目的：与透传路径共用同一套 keepalive 帧与保活语义，消除重复实现。
+            async def _keepalive_transform(item):
+                return await ensure_string(item, as_sse=stream)
+
+            try:
+                async for chunk in iter_sse_with_keepalive(
+                    generator,
+                    interval=timeout,
+                    wait_task=wait_task,
+                    emit_initial=(first_item is None),
+                    transform=_keepalive_transform,
+                ):
+                    yield chunk
+                _log_stream_end("upstream_eof")
+                stream_end_logged = True
+            except asyncio.CancelledError:
+                logger.debug(f"provider: {channel_id:<11} Stream cancelled by client in main loop")
+                _log_stream_end("client_cancelled", level="debug")
+                stream_end_logged = True
+            except (
+                httpx.ReadError,
+                httpx.RemoteProtocolError,
+                httpx.ReadTimeout,
+                httpx.WriteError,
+                httpx.ProtocolError,
+                h2.exceptions.ProtocolError,
+            ) as e:
+                logger.error(f"provider: {channel_id:<11} Network error in keepalive loop: {e}")
+
                 try:
-                    item, status = await wait_for_timeout(generator, timeout=timeout, wait_task=wait_task)
-                    if status == "timeout":
-                        # 关键：复用仍在运行的 __anext__ 任务，避免并发创建导致重入
-                        wait_task = item
-                        yield ": keepalive\n\n"
-                    elif status == "reentrant":
-                        # 理论上不应频繁出现；出现时按正常心跳周期退避，避免刷屏
-                        wait_task = None
-                        await asyncio.sleep(timeout)
-                        yield ": keepalive\n\n"
-                    else:
-                        yield await ensure_string(item, as_sse=stream)
-                        wait_task = None
-                except asyncio.CancelledError:
-                    logger.debug(f"provider: {channel_id:<11} Stream cancelled by client in main loop")
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    _log_stream_end("client_cancelled", level="debug")
-                    stream_end_logged = True
-                    break
-                except StopAsyncIteration:
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    _log_stream_end("upstream_eof")
-                    stream_end_logged = True
-                    break
-                except (
-                    httpx.ReadError,
-                    httpx.RemoteProtocolError,
-                    httpx.ReadTimeout,
-                    httpx.WriteError,
-                    httpx.ProtocolError,
-                    h2.exceptions.ProtocolError,
-                ) as e:
-                    logger.error(f"provider: {channel_id:<11} Network error in keepalive loop: {e}")
+                    err_str = str(e)
+                    if request_url and app and ("StreamReset" in err_str or "stream_id" in err_str):
+                        from urllib.parse import urlparse
+                        host = urlparse(request_url).netloc
+                        if host and hasattr(app, "state") and hasattr(app.state, "client_manager"):
+                            asyncio.create_task(app.state.client_manager.reset_client(host))
+                except Exception:
+                    pass
 
-                    try:
-                        err_str = str(e)
-                        if request_url and app and ("StreamReset" in err_str or "stream_id" in err_str):
-                            from urllib.parse import urlparse
-                            host = urlparse(request_url).netloc
-                            if host and hasattr(app, "state") and hasattr(app.state, "client_manager"):
-                                asyncio.create_task(app.state.client_manager.reset_client(host))
-                    except Exception:
-                        pass
-
-                    done = "data: [DONE]\n\n" if done_message is None else done_message
-                    if done:
-                        yield done
-
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    _log_stream_end("upstream_network_error", level="warning", detail=type(e).__name__)
-                    stream_end_logged = True
-                    break
-                except RuntimeError as e:
-                    # 兜底保护：极端时序仍可能抛出重入错误，重置等待任务并退避
-                    if "asynchronous generator is already running" in str(e):
-                        wait_task = None
-                        await asyncio.sleep(0.2)
-                        yield ": keepalive\n\n"
-                        continue
-                    logger.error(f"provider: {channel_id:<11} Error in keepalive loop: {e}")
-                    done = "data: [DONE]\n\n" if done_message is None else done_message
-                    if done:
-                        yield done
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    _log_stream_end("wrapper_exception", level="error", detail=type(e).__name__)
-                    stream_end_logged = True
-                    break
-                except Exception as e:
-                    logger.error(f"provider: {channel_id:<11} Error in keepalive loop: {e}")
-                    done = "data: [DONE]\n\n" if done_message is None else done_message
-                    if done:
-                        yield done
-                    if wait_task is not None and not wait_task.done():
-                        wait_task.cancel()
-                    _log_stream_end("wrapper_exception", level="error", detail=type(e).__name__)
-                    stream_end_logged = True
-                    break
+                done = "data: [DONE]\n\n" if done_message is None else done_message
+                if done:
+                    yield done
+                _log_stream_end("upstream_network_error", level="warning", detail=type(e).__name__)
+                stream_end_logged = True
+            except Exception as e:
+                logger.error(f"provider: {channel_id:<11} Error in keepalive loop: {e}")
+                done = "data: [DONE]\n\n" if done_message is None else done_message
+                if done:
+                    yield done
+                _log_stream_end("wrapper_exception", level="error", detail=type(e).__name__)
+                stream_end_logged = True
         else:
             # 原始逻辑：不需要心跳
             try:

--- a/utils.py
+++ b/utils.py
@@ -1079,7 +1079,11 @@ async def error_handling_wrapper(
 
         # 如果需要心跳机制但不使用嵌套生成器方式
         if with_keepalive:
-            yield ": keepalive\n\n"
+            # 修改原因：旧实现只在首包超时时进入 keepalive 分支，因此首包成功后 chunk 间静默不会再发心跳。
+            # 修改方式：允许首包成功后也复用同一个等待循环；只有首包尚未到达时才立即补一个心跳。
+            # 目的：覆盖“上游已经开始 stream 但中途长时间不吐字”的真实空闲场景。
+            if first_item is None:
+                yield ": keepalive\n\n"
             while True:
                 try:
                     item, status = await wait_for_timeout(generator, timeout=timeout, wait_task=wait_task)
@@ -1393,7 +1397,11 @@ async def error_handling_wrapper(
             if (content == "" or content is None) and (tool_calls == "" or tool_calls is None) and (reasoning_content == "" or reasoning_content is None) and b64_json is None:
                 raise StopAsyncIteration
 
-        return new_generator(first_item), first_response_time
+        return new_generator(
+            first_item,
+            with_keepalive=bool(keepalive_interval and stream),
+            timeout=keepalive_interval or 3,
+        ), first_response_time
 
     except StopAsyncIteration:
         # 502 Bad Gateway 是一个更合适的状态码，因为它表明作为代理或网关的服务器从上游服务器收到了无效的响应。


### PR DESCRIPTION
## 概述

本 PR 默认启用应用层 SSE keepalive，修复 Cloudflare 等中间代理在上游空闲期导致的 HTTP 524 断连，并将普通流式与透传流式的心跳实现合并为单一函数。

## 为什么界面上的「Keepalive 心跳间隔 = 25」默认没有生效

设置页显示的 25 和后端实际使用的默认值是两套独立的东西，且此前并不一致。前端 `Settings.tsx` 中 `keepalive_interval?.default ?? 25` 的 `?? 25` 只是空值占位：配置里没有该字段时，输入框显示 25 给用户看，但它不会自动写入后端配置。除非用户手动改值并保存，否则这个 25 始终停留在前端，从未提交到后端。整条链路如下：

| 环节 | 值 | 结果 |
| --- | --- | --- |
| 前端输入框显示 | 25 | 只是占位，没保存就不进配置 |
| 后端真实默认 | 99999 | 用户没动设置时实际生效的就是它 |
| handler 边界判断 | 99999 > 600 | 被置空，keepalive 关闭 |

一句话总结：界面上的 25 制造了一种「默认每 25 秒心跳」的错觉，但它只是个没人保存就不算数的展示数字。后端真正的默认是 99999，又被「大于超时就置空」的逻辑直接关掉，所以默认状态下 keepalive 从来没工作过。

这正是本 PR 的两个修复动作：一是把后端默认从 99999 改成 15，并把前端占位也改成 15，让两边对齐、不再互相误导；二是用 `normalize_keepalive_interval` 收紧边界判断，确保这个 15 秒能稳定落地生效。

---

## fix(streaming): 默认启用 SSE keepalive 并覆盖首包后 idle

根因：Cloudflare Free/Pro 等中间代理对 HTTP 长连接有 ~100s 空闲超时，
模型思考/检索/排队期间无字节流过会导致 SSE 客户端在 100-125s 断开（HTTP 524）。
代码原本已有 keepalive_interval 机制，但默认 99999 且 handler 中
keepalive>timeout 直接置空，等同默认关闭；且旧实现只覆盖首包前静默，
首包成功后 chunk 间空闲不再发心跳，无法对抗"上游中途不吐字"。

修改：
- main.py: 默认 keepalive_interval 改为 15s，新增 KEEPALIVE_INTERVAL 环境变量；
  修复 init_preference 在偏好缺省时丢失启动期默认值的问题
- core/handler.py: 新增 normalize_keepalive_interval()，集中处理类型/边界，
  替换原先 keepalive>timeout 直接置空的内联逻辑
- utils.py: error_handling_wrapper 首包成功后继续走带心跳的等待循环，
  复用 wait_for_timeout 的单飞 __anext__，避免并发拉取上游
- core/passthrough.py: 透传流式路径同样接入 SSE 注释帧 keepalive，
  不解析/改写协议内容
- frontend/src/pages/Settings.tsx: 默认展示值 25 -> 15 与后端对齐

验证：本地 uv 跑 compileall + 最小行为测试（首包后空闲间隙能稳定发出
SSE 注释帧 keepalive，上游恢复吐字时真实 chunk 继续原样转发）通过。


---

## refactor(streaming): 合并 keepalive pump 到 utils.iter_sse_with_keepalive

背景：bfcf490 同时让 utils.error_handling_wrapper 与 core/passthrough._passthrough_error_wrapper
具备 SSE keepalive 能力，但两条路径各自抄了一份几乎相同的 pump 循环：
wait_for_timeout 单飞 __anext__、超时发 ': keepalive\n\n'、重入退避、上游 EOF 收尾，
keepalive 帧样式与挂起任务清理需要两处同步维护，容易改一处漏一处。

修改：
- utils.py: 新增 SSE_KEEPALIVE_COMMENT 常量与 iter_sse_with_keepalive() helper，
  把固有保活循环集中实现；普通流式路径以 ensure_string 作为 transform 注入协议转换；
  pending wait_task 在 finally 中统一 cancel，覆盖 GeneratorExit/异常等所有退出路径，
  修复审核中指出的潜在 wait_task 泄漏。
- core/passthrough.py: final_gen 不再自行维护循环，改调 iter_sse_with_keepalive；
  不传 transform 以保持透传'不解析/不改写协议内容'的约束。

验证：本地 compileall + Junk/keepalive-behavior-test.py 通过
(KEEPALIVE_OK normal_frt=0.0178s passthrough_frt=0.0160s)，
即重构后两条路径仍能在首包后空闲间隙稳定发出 SSE 注释帧。

净效果：删除约 90 行复制代码，行为保持一致，挂起任务清理更稳健。


---

