### PR TITLE
fix(models): preserve slash-prefixed model rules

### DIFF
--- a/core/model_catalog.py
+++ b/core/model_catalog.py
@@ -122,6 +122,22 @@ def _append_authorized_virtual_models(all_models, unique_models, config, api_ind
         _append_model_info_if_missing(all_models, unique_models, virtual_name)
 
 
+def _split_scoped_model_rule(model_rule, config, api_list):
+    """Return provider/model parts only when the prefix names a real provider."""
+    if not isinstance(model_rule, str) or "/" not in model_rule:
+        return None
+
+    provider_name, model_name = model_rule.split("/", 1)
+    is_local_provider = is_local_api_key(provider_name) and provider_name in api_list
+    is_configured_provider = any(
+        provider.get("provider") == provider_name
+        for provider in config.get("providers", [])
+    )
+    if not is_local_provider and not is_configured_provider:
+        return None
+    return provider_name, model_name
+
+
 def post_all_models(api_index, config, api_list, models_list):
     all_models = []
     unique_models = set()
@@ -136,6 +152,7 @@ def post_all_models(api_index, config, api_list, models_list):
     
     if config['api_keys'][api_index]['model']:
         for model in config['api_keys'][api_index]['model']:
+            configured_model = model
             if model == "all":
                 # 如果模型名为 all，则返回所有模型并去重，按分组过滤
                 all_models = get_all_models(config, allowed_groups)
@@ -143,9 +160,22 @@ def post_all_models(api_index, config, api_list, models_list):
                 _append_authorized_virtual_models(all_models, unique_models, config, api_index)
                 all_models.sort(key=lambda x: x["id"])
                 return all_models
-            if "/" in model:
-                provider = model.split("/")[0]
-                model = model.split("/")[1]
+
+            # A slash can be part of the public model ID. Angle brackets are the
+            # existing explicit escape; otherwise only a known provider prefix
+            # is interpreted as provider/model syntax.
+            if (
+                isinstance(model, str)
+                and "/" in model
+                and model.startswith("<")
+                and model.endswith(">")
+            ):
+                _append_model_info_if_missing(all_models, unique_models, model[1:-1])
+                continue
+
+            scoped_rule = _split_scoped_model_rule(model, config, api_list)
+            if scoped_rule is not None:
+                provider, model = scoped_rule
                 if model == "*":
                     if is_local_api_key(provider) and provider in api_list:
                         # 分组过滤：仅当本地聚合器 Key 与当前请求 Key 分组有交集时才包含
@@ -260,6 +290,7 @@ def post_all_models(api_index, config, api_list, models_list):
                             upstream_candidates = {v for k, v in model_dict.items() if v != k}
                             # 如果渠道配置了 model_prefix，只展示带前缀的模型名
                             prefix = provider_item.get('model_prefix', '').strip()
+                            visible_model = configured_model if configured_model in model_dict else model
                             for model_item in model_dict.keys():
                                 # 跳过通配符标记，"*" 不是真实模型名
                                 if model_item == "*":
@@ -275,7 +306,7 @@ def post_all_models(api_index, config, api_list, models_list):
                                 # 如果有前缀，只返回带前缀的模型名
                                 if prefix and not model_item.startswith(prefix):
                                     continue
-                                if model_item not in unique_models and model_item == model:
+                                if model_item not in unique_models and model_item == visible_model:
                                     unique_models.add(model_item)
                                     model_info = {
                                         "id": model_item,

--- a/core/routing.py
+++ b/core/routing.py
@@ -76,6 +76,25 @@ def _append_provider_rule(provider_rules: List[str], provider_name: str, model_n
         provider_rules.append(rule)
 
 
+def _append_literal_model_rules(
+    provider_rules: List[str],
+    model_name: str,
+    config: Dict[str, Any],
+    request_model: str,
+) -> None:
+    """Append providers exposing a public model ID that contains a slash."""
+    for provider in config["providers"]:
+        if provider.get("enabled") is False:
+            continue
+        model_dict = provider["_model_dict_cache"]
+        if model_name in model_dict:
+            _append_provider_rule(provider_rules, provider["provider"], model_name)
+        else:
+            pool_model = _get_pool_sharing_model_name(provider, request_model, model_dict)
+            if model_name == request_model and pool_model:
+                _append_provider_rule(provider_rules, provider["provider"], pool_model)
+
+
 def _is_virtual_model_authorized(request_model: str, config: Dict[str, Any], api_index: int) -> bool:
     """判断当前 API Key 是否允许访问虚拟模型名。"""
     # 修改原因：虚拟模型只是新的模型名入口，必须复用 API Key 的 model 授权数组。
@@ -318,20 +337,18 @@ async def get_provider_rules(
         if model_rule.startswith("<") and model_rule.endswith(">"):
             model_rule = model_rule[1:-1]
             # 处理带斜杠的模型名
-            for provider in config['providers']:
-                # 跳过禁用的渠道
-                if provider.get("enabled") is False:
-                    continue
-                model_dict = provider["_model_dict_cache"]
-                if model_rule in model_dict.keys():
-                    _append_provider_rule(provider_rules, provider['provider'], model_rule)
-                else:
-                    pool_model = _get_pool_sharing_model_name(provider, request_model, model_dict)
-                    if model_rule == request_model and pool_model:
-                        _append_provider_rule(provider_rules, provider['provider'], pool_model)
+            _append_literal_model_rules(provider_rules, model_rule, config, request_model)
         else:
-            provider_name = model_rule.split("/")[0]
-            model_name_split = "/".join(model_rule.split("/")[1:])
+            provider_name, model_name_split = model_rule.split("/", 1)
+            is_local_provider = is_local_api_key(provider_name) and provider_name in app.state.api_list
+            is_configured_provider = any(
+                provider.get("provider") == provider_name
+                for provider in config["providers"]
+            )
+            if not is_local_provider and not is_configured_provider:
+                _append_literal_model_rules(provider_rules, model_rule, config, request_model)
+                return provider_rules
+
             models_list = []
             matched_provider = None
 
@@ -361,6 +378,16 @@ async def get_provider_rules(
                     request_model,
                     matched_provider["_model_dict_cache"]
                 )
+
+            # If the provider name is also the public model namespace (for
+            # example provider="vendor", model_prefix="vendor/"), prefer the
+            # complete public model ID when it is explicitly requested.
+            if (
+                matched_provider is not None
+                and model_rule == request_model
+                and model_rule in models_list
+            ):
+                _append_provider_rule(provider_rules, provider_name, model_rule)
 
             # api_keys 中 model 为 provider_name/* 时，表示所有模型都匹配
             if model_name_split == "*":

--- a/test/test_model_catalog_slash_prefix.py
+++ b/test/test_model_catalog_slash_prefix.py
@@ -1,0 +1,74 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from core.model_catalog import post_all_models
+from core.routing import get_provider_rules
+
+
+def _provider(name="upstream", prefix="vendor/"):
+    return {
+        "provider": name,
+        "model": ["model-a"],
+        "model_prefix": prefix,
+        "groups": ["default"],
+        "_model_dict_cache": {f"{prefix}model-a": "model-a"},
+    }
+
+
+def _config(rule, provider=None):
+    return {
+        "api_keys": [{
+            "api": "zk-test",
+            "model": [rule],
+            "groups": ["default"],
+        }],
+        "providers": [provider or _provider()],
+        "preferences": {},
+    }
+
+
+def _listed_model_ids(rule, provider=None):
+    config = _config(rule, provider)
+    return [
+        model["id"]
+        for model in post_all_models(0, config, [], {})
+    ]
+
+
+@pytest.mark.parametrize(
+    ("rule", "expected"),
+    [
+        ("vendor/model-a", "vendor/model-a"),
+        ("<vendor/model-a>", "vendor/model-a"),
+        ("upstream/vendor/model-a", "vendor/model-a"),
+        ("upstream/*", "vendor/model-a"),
+    ],
+)
+def test_slash_prefixed_api_key_model_is_listed(rule, expected):
+    assert _listed_model_ids(rule) == [expected]
+
+
+def test_provider_name_can_also_be_the_model_namespace():
+    provider = _provider(name="vendor")
+    assert _listed_model_ids("vendor/model-a", provider) == ["vendor/model-a"]
+
+
+@pytest.mark.parametrize(
+    ("rule", "provider", "expected"),
+    [
+        ("vendor/model-a", _provider(), ["upstream/vendor/model-a"]),
+        ("<vendor/model-a>", _provider(), ["upstream/vendor/model-a"]),
+        ("upstream/vendor/model-a", _provider(), ["upstream/vendor/model-a"]),
+        ("upstream/*", _provider(), ["upstream/vendor/model-a"]),
+        ("vendor/model-a", _provider(name="vendor"), ["vendor/vendor/model-a"]),
+    ],
+)
+def test_slash_prefixed_api_key_rule_routes_to_exposing_provider(rule, provider, expected):
+    config = _config(rule, provider)
+    app = SimpleNamespace(state=SimpleNamespace(api_list=[], models_list={}))
+
+    rules = asyncio.run(get_provider_rules(rule, config, "vendor/model-a", app))
+
+    assert rules == expected


### PR DESCRIPTION
## Summary

- distinguish slash-prefixed public model IDs from `provider/model` access rules
- preserve nested model paths and the existing `<model/name>` escape syntax
- keep `/v1/models` discovery and request routing authorization consistent

## Tests

- `uv run --frozen pytest -q test/test_model_catalog_slash_prefix.py` (10 passed)
- `uv run --frozen pytest -q tests test/test_model_catalog_slash_prefix.py` (19 passed)
- `uv run --frozen python -m compileall -q core/model_catalog.py core/routing.py`

## Baseline note

The repository-wide `pytest -q` currently has pre-existing collection errors under `core/test` due to package-relative imports, plus async tests require `pytest-asyncio`; neither is changed by this PR.