### PR TITLE
fix: grant admin keys all channel model access

### DIFF
--- a/core/api_key_access.py
+++ b/core/api_key_access.py
@@ -1,0 +1,12 @@
+"""Shared API-key role checks used by catalog and request routing."""
+
+from typing import Any, Mapping
+
+
+def is_admin_api_key(config: Mapping[str, Any], api_index: int) -> bool:
+    """Return whether the configured API key at *api_index* has an admin role."""
+    try:
+        key = (config.get("api_keys") or [])[api_index]
+    except (IndexError, TypeError):
+        return False
+    return isinstance(key, Mapping) and "admin" in str(key.get("role") or "").lower()

--- a/core/model_catalog.py
+++ b/core/model_catalog.py
@@ -5,6 +5,7 @@
 # 修改原因：该模块承载业务逻辑，不应继续放在 utils_pkg 这种通用工具包中。
 # 修改方式：按照 Scout 的归位方案迁移到 core 对应业务模块，并只调整必要的内部导入路径。
 # 目的：让业务代码按领域归属维护，同时保留根 utils.py 和 utils_pkg shim 的旧导入兼容性。
+from core.api_key_access import is_admin_api_key
 from core.utils import get_model_dict, is_local_api_key, safe_get
 
 
@@ -44,7 +45,8 @@ def _append_authorized_virtual_models(all_models, unique_models, config, api_ind
     allow_all = "all" in normalized_rules
     allowed_names = set(normalized_rules)
 
-    # 当前 API Key 允许的分组
+    # Admin keys can reach every enabled provider; ordinary keys retain group isolation.
+    admin_access = is_admin_api_key(config, api_index)
     api_key_groups = safe_get(config, 'api_keys', api_index, 'groups', default=['default'])
     if isinstance(api_key_groups, str):
         api_key_groups = [api_key_groups]
@@ -90,7 +92,7 @@ def _append_authorized_virtual_models(all_models, unique_models, config, api_ind
                 if node_type == "channel":
                     target_provider = target.get("value", "")
                     target_groups = provider_groups_map.get(target_provider)
-                    if target_groups and allowed_groups.intersection(target_groups):
+                    if target_groups and (admin_access or allowed_groups.intersection(target_groups)):
                         has_accessible_provider = True
                         break
                 elif node_type == "model":
@@ -101,7 +103,7 @@ def _append_authorized_virtual_models(all_models, unique_models, config, api_ind
                             p_model_dict = p.get("_model_dict_cache") or {}
                             if model_value in p_model_dict:
                                 p_grps = provider_groups_map.get(pname)
-                                if p_grps and allowed_groups.intersection(p_grps):
+                                if p_grps and (admin_access or allowed_groups.intersection(p_grps)):
                                     has_accessible_provider = True
                                     break
                     if has_accessible_provider:
@@ -114,7 +116,7 @@ def _append_authorized_virtual_models(all_models, unique_models, config, api_ind
                     p_model_dict = p.get("_model_dict_cache") or {}
                     if virtual_name in p_model_dict:
                         p_grps = provider_groups_map.get(pname)
-                        if p_grps and allowed_groups.intersection(p_grps):
+                        if p_grps and (admin_access or allowed_groups.intersection(p_grps)):
                             has_accessible_provider = True
                             break
             if not has_accessible_provider:
@@ -142,7 +144,8 @@ def post_all_models(api_index, config, api_list, models_list):
     all_models = []
     unique_models = set()
 
-    # 允许分组集合：仅返回与当前 API Key 分组有交集的渠道模型
+    # Admin keys list every enabled provider; ordinary keys are restricted by groups.
+    admin_access = is_admin_api_key(config, api_index)
     api_key_groups = safe_get(config, 'api_keys', api_index, 'groups', default=['default'])
     if isinstance(api_key_groups, str):
         api_key_groups = [api_key_groups]
@@ -155,7 +158,7 @@ def post_all_models(api_index, config, api_list, models_list):
             configured_model = model
             if model == "all":
                 # 如果模型名为 all，则返回所有模型并去重，按分组过滤
-                all_models = get_all_models(config, allowed_groups)
+                all_models = get_all_models(config, None if admin_access else allowed_groups)
                 unique_models = {item["id"] for item in all_models}
                 _append_authorized_virtual_models(all_models, unique_models, config, api_index)
                 all_models.sort(key=lambda x: x["id"])

--- a/core/routing.py
+++ b/core/routing.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Any, TYPE_CHECKING
 
 from fastapi import HTTPException
 
+from core.api_key_access import is_admin_api_key
 from core.log_config import logger
 from core.utils import (
     get_model_dict,
@@ -118,6 +119,11 @@ def _filter_provider_list(
     api_index: int,
 ) -> List[Dict[str, Any]]:
     """复用黑名单和分组过滤逻辑。"""
+    # Administrator keys intentionally bypass user-configurable model/channel/group filters.
+    # Disabled providers have already been removed while building the candidate list.
+    if is_admin_api_key(config, api_index):
+        return provider_list
+
     # 修改原因：虚拟模型候选池和普通模型候选池都必须经过同一套 API Key 过滤。
     # 修改方式：把 get_matching_providers 中的过滤逻辑抽成独立函数。
     # 目的：让虚拟模型注入点只替换候选池生成，不改变黑名单与分组语义。

--- a/routes/models.py
+++ b/routes/models.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from core.byok import get_byok_real_key, is_byok_provider
+from core.api_key_access import is_admin_api_key
 from core.channels import get_channel
 from core.http import proxy_context
 from core.log_config import logger
@@ -97,6 +98,7 @@ async def build_models_for_request(api_index: int, app=None) -> List[Dict[str, A
     if not isinstance(api_key_groups, list) or not api_key_groups:
         api_key_groups = ["default"]
     allowed_groups = set(api_key_groups)
+    admin_access = is_admin_api_key(app.state.config, api_index)
 
     api_models = safe_get(app.state.config, "api_keys", api_index, "model", default=[]) or []
     authorized_byok_providers = set()
@@ -120,7 +122,7 @@ async def build_models_for_request(api_index: int, app=None) -> List[Dict[str, A
             continue
         if is_local_api_key(provider.get("provider", "")):
             continue
-        if not _provider_groups_allowed(provider, allowed_groups):
+        if not admin_access and not _provider_groups_allowed(provider, allowed_groups):
             continue
         provider_name = provider.get("provider")
         if not allow_all and provider_name not in authorized_byok_providers:

--- a/test/test_admin_model_access.py
+++ b/test/test_admin_model_access.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core.model_catalog import post_all_models
+from core.routing import get_matching_providers
+
+
+def _provider(name, model, group, enabled=True):
+    return {
+        "provider": name,
+        "model": [model],
+        "groups": [group],
+        "enabled": enabled,
+        "_model_dict_cache": {model: model},
+    }
+
+
+def _config(role="admin"):
+    return {
+        "api_keys": [{
+            "api": "hidden",
+            "role": role,
+            "model": ["all"],
+            "groups": ["tier-a"],
+            "preferences": {
+                "excluded_channels": ["tier-b-provider"],
+                "excluded_models": ["model-b"],
+            },
+        }],
+        "providers": [
+            _provider("tier-a-provider", "model-a", "tier-a"),
+            _provider("tier-b-provider", "model-b", "tier-b"),
+            _provider("disabled-provider", "model-disabled", "tier-b", enabled=False),
+        ],
+        "preferences": {},
+    }
+
+
+class _App:
+    state = SimpleNamespace(api_list=[], models_list={})
+
+
+def test_admin_model_catalog_lists_all_enabled_groups():
+    ids = {item["id"] for item in post_all_models(0, _config(), [], {})}
+    assert ids == {"model-a", "model-b"}
+
+
+@pytest.mark.asyncio
+async def test_admin_routing_bypasses_groups_and_user_exclusions():
+    matched = await get_matching_providers("model-b", _config(), 0, _App())
+    assert [item["provider"] for item in matched] == ["tier-b-provider"]
+
+
+def test_ordinary_model_catalog_keeps_group_isolation():
+    ids = {item["id"] for item in post_all_models(0, _config(role="user"), [], {})}
+    assert ids == {"model-a"}
+
+
+@pytest.mark.asyncio
+async def test_ordinary_routing_keeps_groups_and_exclusions():
+    assert await get_matching_providers("model-b", _config(role="user"), 0, _App()) == []


### PR DESCRIPTION
Admin API keys now bypass ordinary user channel groups and per-key excluded channel/model filters in both model discovery and request routing, while disabled providers remain unavailable. Ordinary keys retain existing isolation.\n\nTests: 19 targeted tests passed.